### PR TITLE
fix core_config_data re-encryption

### DIFF
--- a/Console/GenerateEncryptionKey.php
+++ b/Console/GenerateEncryptionKey.php
@@ -12,6 +12,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Store\Model\App\Emulation;
+use Magento\Framework\App\State;
 
 class GenerateEncryptionKey extends Command
 {
@@ -22,6 +24,8 @@ class GenerateEncryptionKey extends Command
      * @param CacheInterface $cache
      * @param ScopeConfigInterface $scopeConfig
      * @param WriterInterface $configWriter
+     * @param Emulation $emulation
+     * @param State $state
      * @param Encryptor $encryptor
      */
     public function __construct(
@@ -29,6 +33,8 @@ class GenerateEncryptionKey extends Command
         private readonly CacheInterface $cache,
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly WriterInterface $configWriter,
+        private readonly Emulation $emulation,
+        private readonly State $state,
         private readonly Encryptor $encryptor
     ) {
         parent::__construct();
@@ -76,9 +82,12 @@ class GenerateEncryptionKey extends Command
              *
              * @see \Magento\EncryptionKey\Controller\Adminhtml\Crypt\Key\Save::execute()
              */
+            $this->state->setAreaCode('adminhtml');
+            $this->emulation->startEnvironmentEmulation(0, 'adminhtml');
             $output->writeln('Generating a new encryption key using the magento core class');
             $this->changeEncryptionKey->setOutput($output);
             $this->changeEncryptionKey->changeEncryptionKey();
+            $this->emulation->stopEnvironmentEmulation();
             $output->writeln('Cleaning cache');
 
             $value = $this->scopeConfig->getValue('gene/encryption_key_manager/invalidated_key_index');

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,12 @@
         </arguments>
     </type>
 
+    <type name="Gene\EncryptionKeyManager\Service\ChangeEncryptionKey">
+        <arguments>
+            <argument name="structure" xsi:type="object">Magento\Config\Model\Config\StructureLazy</argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
This needs to be loaded as adminhtml to get the scope config structure to identify the config paths for

```php
    protected function _reEncryptSystemConfigurationValues()
    {
        // look for encrypted node entries in all system.xml files
        /** @var \Magento\Config\Model\Config\Structure $configStructure  */
        $configStructure = $this->structure;
        $paths = $configStructure->getFieldPathsByAttribute(
            'backend_model',
            \Magento\Config\Model\Config\Backend\Encrypted::class
        );

        // walk through found data and re-encrypt it
        if ($paths) {
            $table = $this->getTable('core_config_data');
            $values = $this->getConnection()->fetchPairs(
                $this->getConnection()
                    ->select()
                    ->from($table, ['config_id', 'value'])
                    ->where('path IN (?)', $paths)
                    ->where('value NOT LIKE ?', '')
            );
            foreach ($values as $configId => $value) {
                $this->getConnection()->update(
                    $table,
                    ['value' => $this->encryptor->encrypt($this->encryptor->decrypt($value))],
                    ['config_id = ?' => (int)$configId]
                );
            }
        }
    }
```