### PR TITLE
Fix `config:set --lock-env` command

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,12 @@
         </arguments>
     </type>
 
+    <type name="Gene\EncryptionKeyManager\Console\GenerateEncryptionKey">
+        <arguments>
+            <argument name="changeEncryptionKey" xsi:type="object">Gene\EncryptionKeyManager\Service\ChangeEncryptionKey\Proxy</argument>
+        </arguments>
+    </type>
+
     <type name="Gene\EncryptionKeyManager\Service\ChangeEncryptionKey">
         <arguments>
             <argument name="structure" xsi:type="object">Magento\Config\Model\Config\StructureLazy</argument>


### PR DESCRIPTION
This would force the structure to load partially in the background, so force it as a proxy

Testing this
```
php bin/magento config:set --lock-env dev/js/enable_magepack_js_bundling 1
```