### PR TITLE
Add command to reencrypt specific table/column pair

### DIFF
--- a/Console/ReencryptColumn.php
+++ b/Console/ReencryptColumn.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+namespace Gene\EncryptionKeyManager\Console;
+
+use Composer\Console\Input\InputArgument;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Console\Cli;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReencryptColumn extends Command
+{
+    public const INPUT_KEY_FORCE = 'force';
+    public const INPUT_KEY_TABLE = 'table';
+    public const INPUT_KEY_IDENTIFIER = 'identifier';
+    public const INPUT_KEY_COLUMN = 'column';
+
+    /**
+     * @param DeploymentConfig $deploymentConfig
+     * @param ResourceConnection $resourceConnection
+     * @param EncryptorInterface $encryptor
+     * @param CacheInterface $cache
+     */
+    public function __construct(
+        private readonly DeploymentConfig $deploymentConfig,
+        private readonly ResourceConnection $resourceConnection,
+        private readonly EncryptorInterface $encryptor,
+        private readonly CacheInterface $cache
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @return void
+     */
+    protected function configure()
+    {
+        $options = [
+            new InputOption(
+                self::INPUT_KEY_FORCE,
+                null,
+                InputOption::VALUE_NONE,
+                'Whether to force this action to take effect'
+            ),
+            new InputArgument(
+                self::INPUT_KEY_TABLE,
+                null,
+                'The table containing the data to re-encrypt',
+                ''
+            ),
+            new InputArgument(
+                self::INPUT_KEY_IDENTIFIER,
+                null,
+                'The entity_id, row_id, or equivalent for the table',
+                ''
+            ),
+            new InputArgument(
+                self::INPUT_KEY_COLUMN,
+                null,
+                'The column that you want to re-encrypt',
+                ''
+            )
+        ];
+
+        $this->setName('gene:encryption-key-manager:reencrypt-column');
+        $this->setDescription('Re-encrypt a columns data with the latest key');
+        $this->setDefinition($options);
+
+        parent::configure();
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$input->getOption(self::INPUT_KEY_FORCE)) {
+            $output->writeln('<info>Run with --force to make these changes, this will run in dry-run mode by default</info>');
+        }
+
+        try {
+            $keys = preg_split('/\s+/s', trim((string)$this->deploymentConfig->get('crypt/key')));
+            $latestKeyNumber = count($keys) - 1;
+            $output->writeln("The latest encryption key is number $latestKeyNumber, looking for old entries");
+
+            $table = $input->getArgument(self::INPUT_KEY_TABLE);
+            if (!strlen($table)) {
+                throw new \Exception('Provide a table name');
+            }
+            if (in_array($table, ['core_config_data', 'tfa_user_config'])) {
+                throw new \Exception('You cannot use this command for this table');
+            }
+            $identifier = $input->getArgument(self::INPUT_KEY_IDENTIFIER);
+            if (!strlen($identifier)) {
+                throw new \Exception('Provide an identifier');
+            }
+            $column = $input->getArgument(self::INPUT_KEY_COLUMN);
+            if (!strlen($column)) {
+                throw new \Exception('Provide an column');
+            }
+            $output->writeln("Looking for '$column' in '$table', identified by '$identifier'");
+
+            /**
+             * @see \Magento\Framework\Model\ResourceModel\Db\AbstractDb::_getLoadSelect()
+             */
+            $tableName = $this->resourceConnection->getTableName($table);
+            $connection = $this->resourceConnection->getConnection();
+            $field = $connection->quoteIdentifier(sprintf('%s.%s', $tableName, $column));
+
+            $select = $connection->select()
+                ->from($tableName, [$identifier, "$column"])
+                ->where("($field LIKE '_:_:____%' OR $field LIKE '__:_:____%')")
+                ->where("$field NOT LIKE ?", "$latestKeyNumber:_:__%");
+
+            $result = $connection->fetchAll($select);
+            if (empty($result)) {
+                $output->writeln('No old entries found');
+                return Cli::RETURN_SUCCESS;
+            }
+            $connection->beginTransaction();
+            foreach ($result as $row) {
+                $output->writeln(str_pad('', 120, '#'));
+                $output->writeln("$identifier: {$row[$identifier]}");
+                $value = $row[$column];
+                $output->writeln("ciphertext_old: " . $value);
+                $valueDecrypted = $this->encryptor->decrypt($value);
+                $output->writeln("plaintext: " . $valueDecrypted);
+                $valueEncrypted = $this->encryptor->encrypt($valueDecrypted);
+                $output->writeln("ciphertext_new: " . $valueEncrypted);
+
+                if ($input->getOption(self::INPUT_KEY_FORCE)) {
+                    $connection->update(
+                        $tableName,
+                        [$column => $valueEncrypted],
+                        ["$identifier = ?" => $row[$identifier]]
+                    );
+                } else {
+                    $output->writeln('Dry run mode, no changes have been made');
+                }
+                $output->writeln(str_pad('', 120, '#'));
+            }
+
+            $connection->commit();
+            $this->cache->clean();
+            $output->writeln('Done');
+        } catch (\Throwable $throwable) {
+            if ($this->resourceConnection->getConnection()->getTransactionLevel() > 0) {
+                $this->resourceConnection->getConnection()->rollBack();
+            }
+            $output->writeln("<error>" . $throwable->getMessage() . "</error>");
+            $output->writeln($throwable->getTraceAsString(), OutputInterface::VERBOSITY_VERBOSE);
+            return Cli::RETURN_FAILURE;
+        }
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ yotpo_sync_queue
    1. `Magento\JwtUserToken\Model\SecretBasedJwksFactory` will only use the most recently generated key at the highest index
 4. **Fix missing config values** `php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data`
    1. Re-run to verify `php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data`
-5. When you are happy you can **invalidate your old key** `php bin/magento gene:encryption-key-manager:invalidate`
+5. Fix up all additional identified columns like so, be careful to verify each table and column as this may not be an exhaustive list (also be aware of `entity_id` versus `row_id`)
+    6. `bin/magento gene:encryption-key-manager:reencrypt-column customer_entity entity_id rp_token`
+6. When you are happy you can **invalidate your old key** `php bin/magento gene:encryption-key-manager:invalidate`
    1. `Magento\Catalog\Model\View\Asset\Image` will continue to use the key at the `0` index in the `crypt/invalidated_key` section
 6. Test, test test! Your areas of focus for testing include
 - all integrations that use Magento's APIs
@@ -137,6 +139,29 @@ plaintext: some_secret_here
 ciphertext_new: 14:3:xyz456
 Dry run mode, no changes have been made
 ################################################################################
+Done
+```
+
+## bin/magento gene:encryption-key-manager:reencrypt-column
+
+This allows you to target a specific column for re-encryption.
+
+This command runs in dry run mode by default, do that as a first pass to see the changes that will be made. When you are happy run with `--force`.
+
+You should identify all columns that need to be handled, and run them through this process.
+
+```bash
+$ bin/magento gene:encryption-key-manager:reencrypt-column customer_entity entity_id rp_token
+Run with --force to make these changes, this will run in dry-run mode by default
+The latest encryption key is number 1, looking for old entries
+Looking for 'rp_token' in 'customer_entity', identified by 'entity_id'
+########################################################################################################################
+entity_id: 9876
+ciphertext_old: 0:3:54+QHWqhSwuncAa87Ueph7xF9qPL1CT6+M9Z5AWuup447J33KGVw+Q+BvVLSKR1H1umiq69phKq5NEHk
+plaintext: acb123
+ciphertext_new: 1:3:Y52lxB2VDnKeOHa0hf7kG/d15oooib6GQOYTcAmzfuEnhfW64NAdNN4YjRrhlh2IzQBO5IbwS48JDDRh
+Dry run mode, no changes have been made
+########################################################################################################################
 Done
 ```
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -31,6 +31,7 @@
                 <item name="gene_encryption_key_generate" xsi:type="object">Gene\EncryptionKeyManager\Console\GenerateEncryptionKey</item>
                 <item name="gene_encryption_key_invalidate" xsi:type="object">Gene\EncryptionKeyManager\Console\InvalidateOldEncryptionKeys</item>
                 <item name="gene_encryption_key_reencrypt" xsi:type="object">Gene\EncryptionKeyManager\Console\ReencryptUnhandledCoreConfigData</item>
+                <item name="gene_encryption_key_reencryptcolumn" xsi:type="object">Gene\EncryptionKeyManager\Console\ReencryptColumn</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Show that everything is up to date
```bash
$ bin/magento gene:encryption-key-manager:reencrypt-column customer_entity entity_id rp_token
Run with --force to make these changes, this will run in dry-run mode by default
The latest encryption key is number 1, looking for old entries
Looking for 'rp_token' in 'customer_entity', identified by 'entity_id'
No old entries found
```

Then generated a new key
```bash
$ php bin/magento gene:enc:generate --force
The system currently has 2 keys
Generating a new encryption key using the magento core class
_reEncryptSystemConfigurationValues - start
_reEncryptSystemConfigurationValues - end
_reEncryptCreditCardNumbers - start
_reEncryptCreditCardNumbers - end
Cleaning cache
Done
```

Then ran to see a flagged issue that was corrected

```bash
$ bin/magento gene:encryption-key-manager:reencrypt-column customer_entity entity_id rp_token --force
The latest encryption key is number 3, looking for old entries
Looking for 'rp_token' in 'customer_entity', identified by 'entity_id'
########################################################################################################################
entity_id: 967427
ciphertext_old: 2:3:redacted
plaintext: abc123
ciphertext_new: 3:3:redacted
########################################################################################################################
Done
```

Then ran again to verify it was fixed

```bash
$ bin/magento gene:encryption-key-manager:reencrypt-column customer_entity entity_id rp_token
Run with --force to make these changes, this will run in dry-run mode by default
The latest encryption key is number 3, looking for old entries
Looking for 'rp_token' in 'customer_entity', identified by 'entity_id'
No old entries found
```