### PR TITLE
Add admin_user and admin_adobe_ims_webapi to the list of tables that contain encrypted values

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ customer_entity
 oauth_token
 oauth_consumer
 tfa_user_config
+admin_adobe_ims_webapi
 yotpo_sync_queue
 ```
 2. **Review functions** using `->hash(` from the encryptor class. Changing the keys will result in a different hash.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This will force the JWT factory to use the newly generated key. Other areas of t
 1. **Review your database** for any tables with encrypted values. 
 ```bash
 $ zgrep -h -E '0:3:' database.sql.gz | colrm 500 | grep -Eo ".{0,255}\` VALUES" | uniq | sed -e 's/INSERT.INTO..//' -e 's/..VALUES//'
+admin_user
 core_config_data
 customer_entity
 oauth_token

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ oauth_token
 oauth_consumer
 tfa_user_config
 admin_adobe_ims_webapi
+adobe_user_profile
 yotpo_sync_queue
 ```
 2. **Review functions** using `->hash(` from the encryptor class. Changing the keys will result in a different hash.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,13 @@ yotpo_sync_queue
    1. `Magento\JwtUserToken\Model\SecretBasedJwksFactory` will only use the most recently generated key at the highest index
 4. **Fix missing config values** `php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data`
    1. Re-run to verify `php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data`
-5. Fix up all additional identified columns like so, be careful to verify each table and column as this may not be an exhaustive list (also be aware of `entity_id` versus `row_id`)
-    1. `bin/magento gene:encryption-key-manager:reencrypt-column customer_entity entity_id rp_token`
+5. Fix up all additional identified columns like so, be careful to verify each table and column as this may not be an exhaustive list (also be aware of `entity_id`, `row_id` and `id`)
+    1. `bin/magento gene:encryption-key-manager:reencrypt-column admin_user user_id rp_token`
+    2. `bin/magento gene:encryption-key-manager:reencrypt-column customer_entity entity_id rp_token`
+    3. `bin/magento gene:encryption-key-manager:reencrypt-column oauth_token entity_id secret`
+    4. `bin/magento gene:encryption-key-manager:reencrypt-column oauth_consumer entity_id secret`
+    5. `bin/magento gene:encryption-key-manager:reencrypt-column admin_adobe_ims_webapi id access_token`
+    6. `bin/magento gene:encryption-key-manager:reencrypt-column adobe_user_profile id access_token`
 6. When you are happy you can **invalidate your old key** `php bin/magento gene:encryption-key-manager:invalidate`
    1. `Magento\Catalog\Model\View\Asset\Image` will continue to use the key at the `0` index in the `crypt/invalidated_key` section
 6. Test, test test! Your areas of focus for testing include


### PR DESCRIPTION
- Add `admin_user` (`rp_token` field), `adobe_user_profile` (`access_token` field), and `admin_adobe_ims_webapi` (`access_token` field) to the list of tables that contain encrypted values.
- Add the example commands for additional tables.
Reference:
    - `admin_user` table https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/User/etc/db_schema.xml#L30
    - `customer_entity` table  https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/Customer/etc/db_schema.xml#L37
    - `oauth_token` table https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/Integration/etc/db_schema.xml#L49
    - `oauth_consumer` table https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/Integration/etc/db_schema.xml#L19
    - `admin_adobe_ims_webapi` table https://github.com/magento/adobe-ims/blob/2.2.2/AdminAdobeIms/etc/db_schema.xml#L13
    - `adobe_user_profile` table https://github.com/magento/adobe-ims/blob/2.2.2/AdobeIms/etc/db_schema.xml#L16
