### PR TITLE
Add logging to the `decrypt` function to trace unhandled data

### DIFF
--- a/Plugin/LogDecrypts.php
+++ b/Plugin/LogDecrypts.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+namespace Gene\EncryptionKeyManager\Plugin;
+
+use Psr\Log\LoggerInterface;
+use Magento\Framework\Encryption\Encryptor;
+use Magento\Framework\App\DeploymentConfig;
+
+class LogDecrypts
+{
+    /** @var int  */
+    private $keyCount = 0;
+
+    /** @var bool  */
+    private $enabled = false;
+
+    /** @var bool  */
+    private $onlyLogOldKeyDecryptions = false;
+
+    /**
+     * @param Encryptor $encryptor
+     * @param DeploymentConfig $deploymentConfig
+     * @param LoggerInterface $logger
+     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws \Magento\Framework\Exception\RuntimeException
+     */
+    public function __construct(
+        Encryptor $encryptor,
+        DeploymentConfig $deploymentConfig,
+        private readonly LoggerInterface $logger
+    ) {
+        $this->keyCount = count(explode(PHP_EOL, $encryptor->exportKeys())) - 1;
+
+        // These need to come from deployment config because it is triggered so early in the request flow
+        $this->enabled = (bool)$deploymentConfig->get(
+            'system/default/dev/debug/gene_encryption_manager_enable_decrypt_logging',
+            false
+        );
+        $this->onlyLogOldKeyDecryptions = (bool)$deploymentConfig->get(
+            'system/default/dev/debug/gene_encryption_manager_only_log_old_decrypts',
+            false
+        );
+    }
+
+    /**
+     * Log the source of a decryption, so that we can verify all keys are properly rotated
+     *
+     * @param Encryptor $subject
+     * @param $result
+     * @param $data
+     * @return mixed
+     */
+    public function afterDecrypt(Encryptor $subject, $result, $data)
+    {
+        if (!$this->enabled) {
+            return $result;
+        }
+        try {
+            if (!(is_string($data) && strlen($data) > 5)) {
+                // Not a string matching '0:0:X' or longer
+                return $result;
+            }
+            if ($this->onlyLogOldKeyDecryptions && str_starts_with($data, $this->keyCount . ':')) {
+                // We are decrypting a value identified by the current maximum key, no need to log
+                return $result;
+            }
+
+            /**
+             * This is a bit odd looking but it puts the entire trace in one line, many log management systems do not
+             * like multi line logs and this can make it a bit easier to trace / filter in those systems
+             *
+             * Make the log entry single pipe separated line
+             * Remove full path from trace for easier reading
+             * BP defined at app/autoload.php
+             */
+            $traceString = str_replace(PHP_EOL, '|', (new \Exception)->getTraceAsString());
+            $traceString = '|' . str_replace(BP . '/', '', $traceString);
+
+            $this->logger->info(
+                'gene encryption manager - legacy decryption',
+                [
+                    'trace' => $traceString
+                ]
+            );
+        } catch (\Throwable $throwable) {
+            $this->logger->error(
+                'gene encryption manager - error logging',
+                [
+                    'message' => $throwable->getMessage(),
+                ]
+            );
+        }
+        return $result;
+    }
+}

--- a/Plugin/LogDecrypts.php
+++ b/Plugin/LogDecrypts.php
@@ -65,6 +65,18 @@ class LogDecrypts
                 return $result;
             }
 
+            $exception = new \Exception();
+
+            /**
+             * Generate a trace identifier based on the stack trace excluding any args
+             */
+            $traceIdentifier = [];
+            foreach ($exception->getTrace() as $trace) {
+                unset($trace['args']);
+                $traceIdentifier[] = implode($trace);
+            }
+            $traceIdentifier = md5(implode($traceIdentifier));
+
             /**
              * This is a bit odd looking but it puts the entire trace in one line, many log management systems do not
              * like multi line logs and this can make it a bit easier to trace / filter in those systems
@@ -73,12 +85,13 @@ class LogDecrypts
              * Remove full path from trace for easier reading
              * BP defined at app/autoload.php
              */
-            $traceString = str_replace(PHP_EOL, '|', (new \Exception)->getTraceAsString());
+            $traceString = str_replace(PHP_EOL, '|', $exception->getTraceAsString());
             $traceString = '|' . str_replace(BP . '/', '', $traceString);
 
             $this->logger->info(
                 'gene encryption manager - legacy decryption',
                 [
+                    'trace_id' => $traceIdentifier,
                     'trace' => $traceString
                 ]
             );

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ adobe_user_profile
     4. `bin/magento gene:encryption-key-manager:reencrypt-column oauth_consumer entity_id secret`
     5. `bin/magento gene:encryption-key-manager:reencrypt-column admin_adobe_ims_webapi id access_token`
     6. `bin/magento gene:encryption-key-manager:reencrypt-column adobe_user_profile id access_token`
-6. When you are happy you can **invalidate your old key** `php bin/magento gene:encryption-key-manager:invalidate`
+6. At this point you should have all your data migrated to your new encryption key, to help you verify this you can do the following
+   1. `php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_enable_decrypt_logging 1`
+   2. `php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_only_log_old_decrypts 1`
+   3. Monitor your logs for "gene encryption manager" to verify nothing is still using the old key
+7. When you are happy you can **invalidate your old key** `php bin/magento gene:encryption-key-manager:invalidate`
    1. `Magento\Catalog\Model\View\Asset\Image` will continue to use the key at the `0` index in the `crypt/invalidated_key` section
 6. Test, test test! Your areas of focus for testing include
 - all integrations that use Magento's APIs
@@ -82,6 +86,17 @@ To avoid having to regenerate all the product media when cycling the encryption 
 
 ## Prevents long running process updating order payments
 This module will also fix an issue where every `sales_order_payment` entry was updated during the key generation process. On large stores this could take a long time. Now only necessary entries with saved card information are updated.
+
+## Logging
+
+This module provides a mechanism to log the source for each call to decrypt. This will produce a lot of data as the magento system configuration is encrypted so each request will trigger a log write.
+
+It is recommended to enable this logging after you have handled the re-encryption of all data in your system, but _before_ you invalidate the old keys. This will give you an indication that you have properly handled everything, because if you see a log written it will tell you that something has been missed and where to go to find the source of the issue.
+
+```bash
+php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_enable_decrypt_logging 1
+php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_only_log_old_decrypts 1
+```
 
 ## bin/magento gene:encryption-key-manager:generate
 

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -13,7 +13,8 @@ PASSWORD='password123'
 echo "Stubbing in some test data"
 vendor/bin/n98-magerun2 --version
 vendor/bin/n98-magerun2 admin:user:create --no-interaction --admin-user "$ADMIN" --admin-email "example$CURRENT_TIMESTAMP@example.com" --admin-password $PASSWORD --admin-firstname adminuser --admin-lastname adminuser
-vendor/bin/n98-magerun2 config:store:set zzzzz/zzzzz/zzzz abc123 --encrypt
+vendor/bin/n98-magerun2 config:store:set zzzzz/zzzzz/zzzz xyz123 --encrypt
+vendor/bin/n98-magerun2 config:store:set dev/debug/debug_logging 1
 FAKE_RP_TOKEN=$(vendor/bin/n98-magerun2 dev:encrypt 'abc123')
 vendor/bin/n98-magerun2 db:query "update admin_user set rp_token='$FAKE_RP_TOKEN' where username='$ADMIN'"
 echo "Generated FAKE_RP_TOKEN=$FAKE_RP_TOKEN and assigned to $ADMIN"
@@ -21,23 +22,47 @@ echo "Generated FAKE_RP_TOKEN=$FAKE_RP_TOKEN and assigned to $ADMIN"
 echo "";echo "";
 
 echo "Verifying commands need to use --force"
-if ! php bin/magento gene:encryption-key-manager:generate | grep -q 'Run with --force'; then
+
+php bin/magento gene:encryption-key-manager:generate > test.txt || true;
+if grep -q 'Run with --force' test.txt; then
     echo "PASS: generate needs to run with force"
+else
+    cat test.txt
+    echo "FAIL: generate needs to run with force" && false
 fi
-if ! php bin/magento gene:encryption-key-manager:invalidate | grep -q 'Run with --force'; then
+
+php bin/magento gene:encryption-key-manager:invalidate > test.txt || true
+if grep -q 'Run with --force' test.txt; then
     echo "PASS: invalidate needs to run with force"
+else
+    cat test.txt
+    echo "FAIL: invalidate needs to run with force" && false
 fi
-if ! php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data | grep -q 'Run with --force'; then
+
+php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data > test.txt || true
+if grep -q 'Run with --force' test.txt; then
     echo "PASS: reencrypt-unhandled-core-config-data needs to run with force"
+else
+    cat test.txt
+    echo "FAIL: reencrypt-unhandled-core-config-data needs to run with force" && false
 fi
-if ! php bin/magento gene:encryption-key-manager:reencrypt-column admin_user user_id rp_token --force | grep -q 'Run with --force'; then
+
+php bin/magento gene:encryption-key-manager:reencrypt-column admin_user user_id rp_token > test.txt || true
+if grep -q 'Run with --force' test.txt; then
     echo "PASS: reencrypt-column needs to run with force"
+else
+    cat test.txt
+    echo "FAIL: reencrypt-column needs to run with force" && false
 fi
 echo "";echo "";
 
 echo "Verifying you cannot invalidate with only 1 key"
-if ! php bin/magento gene:encryption-key-manager:invalidate --force | grep -q 'Cannot invalidate when there is only one key'; then
+php bin/magento gene:encryption-key-manager:invalidate --force > test.txt || true
+if grep -Eq 'Cannot invalidate when there is only one key|No further keys need invalidated' test.txt; then
     echo "PASS: You cannot invalidate with only 1 key"
+else
+    cat test.txt
+    echo "FAIL" && false
 fi
 echo "";echo "";
 
@@ -47,10 +72,10 @@ echo "PASS"
 echo "";echo "";
 
 echo "Running reencrypt-unhandled-core-config-data"
-php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data --force > unhandled.txt
-cat unhandled.txt
-grep -q 'zzzzz/zzzzz/zzzz' unhandled.txt
-grep -q 'abc123' unhandled.txt
+php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data --force > test.txt || (cat test.txt && false)
+cat test.txt
+grep -q 'zzzzz/zzzzz/zzzz' test.txt
+grep -q 'xyz123' test.txt
 echo "PASS"
 echo "";echo "";
 echo "Running reencrypt-unhandled-core-config-data - again to verify it was all processed"
@@ -59,10 +84,10 @@ echo "PASS"
 echo "";echo "";
 
 echo "Running reencrypt-column"
-php bin/magento gene:encryption-key-manager:reencrypt-column admin_user user_id rp_token --force > column.txt
-cat column.txt
-grep -q "$FAKE_RP_TOKEN" column.txt
-grep -q abc123 column.txt
+php bin/magento gene:encryption-key-manager:reencrypt-column admin_user user_id rp_token --force > test.txt || (cat test.txt && false)
+cat test.txt
+grep -q "$FAKE_RP_TOKEN" test.txt
+grep -q abc123 test.txt
 echo "PASS"
 echo "";echo "";
 echo "Running reencrypt-column - again to verify it was all processed"
@@ -77,6 +102,66 @@ php bin/magento gene:encryption-key-manager:invalidate --force | grep --context 
 echo "PASS"
 echo "";echo "";
 
+echo "Testing the decrypt logger"
+
+echo "Testing disable behaviour"
+php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_enable_decrypt_logging 0
+php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_only_log_old_decrypts 0
+php bin/magento cache:flush; php bin/magento | head -1; # clear and warm caches
+rm -f var/log/*.log && php bin/magento | head -1 # trigger a decrypt of the stored system config
+touch var/log/system.log
+ls -l var/log
+if grep -q 'gene encryption manager' var/log/system.log; then
+    cat var/log/system.log
+    echo "FAIL: No logs should be produced without enabling the logger" && false
+else
+    echo "PASS: No logs were produced"
+fi
+echo "";echo "";
+
+echo "Testing that enabling it produces a log"
+php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_enable_decrypt_logging 1
+php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_only_log_old_decrypts 0
+php bin/magento cache:flush; php bin/magento | head -1; # clear and warm caches
+rm -f var/log/*.log && php bin/magento | head -1 # trigger a decrypt of the stored system config
+touch var/log/system.log
+ls -l var/log
+if grep 'gene encryption manager' var/log/system.log | grep -q 'Magento\\'; then
+    echo "PASS: A log was produced"
+else
+    cat var/log/system.log
+    echo "FAIL: A log should be produced" && false
+fi
+echo "";echo "";
+
+echo "Testing that gene_encryption_manager_only_log_old_decrypts=1 stops a log being written"
+php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_only_log_old_decrypts 1
+php bin/magento cache:flush; php bin/magento | head -1; # clear and warm caches
+rm -f var/log/*.log && php bin/magento | head -1 # trigger a decrypt of the stored system config
+touch var/log/system.log
+ls -l var/log
+if grep -q 'gene encryption manager' var/log/system.log; then
+    cat var/log/system.log
+    echo "FAIL: No logs should be produced when the keys are up to date" && false
+else
+    echo "PASS: No logs were produced when the keys were up to date"
+fi
+echo "";echo "";
+
+echo "Testing that gene_encryption_manager_only_log_old_decrypts=1 writes when an old key is used"
+rm -f var/log/*.log && php bin/magento | head -1 # trigger a decrypt of the stored system config
+vendor/bin/n98-magerun2 dev:decrypt '0:3:qwertyuiopasdfghjklzxcvbnm' # we are on a higher key than 0 now
+touch var/log/system.log
+ls -l var/log
+if grep 'gene encryption manager' var/log/system.log | grep -q 'DecryptCommand'; then
+    echo "PASS: We have a log hit when trying to decrypt with the old key"
+else
+    cat var/log/system.log
+    echo "FAIL: We should have a log hit when trying to decrypt using an old key" && false
+fi
+echo "";echo "";
+
 echo "A peek at the env.php"
 grep -A10 "'crypt' =>" app/etc/env.php
+echo "";echo "";
 echo "DONE"

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -160,6 +160,9 @@ else
 fi
 echo "";echo "";
 
+echo "A peek at an example log"
+grep 'gene encryption manager' var/log/system.log | tail -1
+
 echo "A peek at the env.php"
 grep -A10 "'crypt' =>" app/etc/env.php
 echo "";echo "";

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="dev">
+            <group id="debug">
+                <field id="gene_encryption_manager_enable_decrypt_logging" translate="label" type="select" sortOrder="15" showInDefault="0" showInWebsite="0" showInStore="0" canRestore="0">
+                    <label>Enable logging of decrypt calls</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="gene_encryption_manager_only_log_old_decrypts" translate="label" type="select" sortOrder="20" showInDefault="0" showInWebsite="0" showInStore="0" canRestore="0">
+                    <label>Only log when the decryption is with an old key</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
+    <type name="Magento\Framework\Encryption\Encryptor">
+        <plugin name="gene-encryption-key-manager-log-decrypts" type="Gene\EncryptionKeyManager\Plugin\LogDecrypts" disabled="false"/>
+    </type>
+
     <type name="Magento\JwtUserToken\Model\SecretBasedJwksFactory">
         <arguments>
             <argument name="deploymentConfig" xsi:type="object">Gene\EncryptionKeyManager\Model\DeploymentConfig</argument>


### PR DESCRIPTION
## Logging

This resolves https://github.com/genecommerce/module-encryption-key-manager/issues/7

This module provides a mechanism to log the source for each call to decrypt. This will produce a lot of data as the magento system configuration is encrypted so each request will trigger a log write.

It is recommended to enable this logging after you have handled the re-encryption of all data in your system, but _before_ you invalidate the old keys. This will give you an indication that you have properly handled everything, because if you see a log written it will tell you that something has been missed and where to go to find the source of the issue.

```bash
php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_enable_decrypt_logging 1
php bin/magento config:set --lock-env dev/debug/gene_encryption_manager_only_log_old_decrypts 1
```

## Example

```
[2024-07-18T12:56:06.736197+00:00] main.INFO: gene encryption manager - legacy decryption {"trace_id":"29dbea682f3e24653ad5233c871848a2","trace":"|#0 vendor/magento/framework/Interception/Interceptor.php(146): Gene\\EncryptionKeyManager\\Plugin\\LogDecrypts->afterDecrypt()|#1 vendor/magento/framework/Interception/Interceptor.php(153): Magento\\Framework\\Encryption\\Encryptor\\Interceptor->Magento\\Framework\\Interception\\{closure}()|#2 generated/code/Magento/Framework/Encryption/Encryptor/Interceptor.php(23): Magento\\Framework\\Encryption\\Encryptor\\Interceptor->___callPlugins()|#3 phar://vendor/n98/magerun2-dist/n98-magerun2/src/N98/Magento/Command/Developer/DecryptCommand.php(63): Magento\\Framework\\Encryption\\Encryptor\\Interceptor->decrypt()|#4 phar://vendor/n98/magerun2-dist/n98-magerun2/vendor/symfony/console/Command/Command.php(298): N98\\Magento\\Command\\Developer\\decryptCommand->execute()|#5 phar://vendor/n98/magerun2-dist/n98-magerun2/src/N98/Magento/Command/AbstractMagentoCommand.php(249): Symfony\\Component\\Console\\Command\\Command->run()|#6 phar://vendor/n98/magerun2-dist/n98-magerun2/vendor/symfony/console/Application.php(1058): N98\\Magento\\Command\\AbstractMagentoCommand->run()|#7 phar://vendor/n98/magerun2-dist/n98-magerun2/vendor/symfony/console/Application.php(301): Symfony\\Component\\Console\\Application->doRunCommand()|#8 phar://vendor/n98/magerun2-dist/n98-magerun2/src/N98/Magento/Application.php(256): Symfony\\Component\\Console\\Application->doRun()|#9 phar://vendor/n98/magerun2-dist/n98-magerun2/vendor/symfony/console/Application.php(171): N98\\Magento\\Application->doRun()|#10 phar://vendor/n98/magerun2-dist/n98-magerun2/src/N98/Magento/Application.php(364): Symfony\\Component\\Console\\Application->run()|#11 vendor/n98/magerun2-dist/n98-magerun2(8): N98\\Magento\\Application->run()|#12 vendor/bin/n98-magerun2(120): include('...')|#13 {main}"} []
```