### PR TITLE
CLI to re-encrypt data in tfa_user_config table, closes #8

### DIFF
--- a/Console/ReencryptTfaData.php
+++ b/Console/ReencryptTfaData.php
@@ -68,7 +68,6 @@ class ReencryptTfaData extends Command
             $output->writeln('<info>Run with --force to make these changes, this will run in dry-run mode by default</info>');
         }
 
-        $this->recursiveDataProcessor->processNestedEncryptedData();
         try {
             $keys = preg_split('/\s+/s', trim((string)$this->deploymentConfig->get('crypt/key')));
             $latestKeyNumber = count($keys);// - 1;

--- a/Console/ReencryptTfaData.php
+++ b/Console/ReencryptTfaData.php
@@ -66,11 +66,12 @@ class ReencryptTfaData extends Command
     {
         if (!$input->getOption(self::INPUT_KEY_FORCE)) {
             $output->writeln('<info>Run with --force to make these changes, this will run in dry-run mode by default</info>');
+            $output->writeln('<error>This CLI has only been tested with Google Authenticator (TOTP) and U2F (Yubikey, etc). If you use Authy or DUO you *MUST* verify before use.</error>');
         }
 
         try {
             $keys = preg_split('/\s+/s', trim((string)$this->deploymentConfig->get('crypt/key')));
-            $latestKeyNumber = count($keys);// - 1;
+            $latestKeyNumber = count($keys) - 1;
             $output->writeln("The latest encryption key is number $latestKeyNumber, looking for old entries");
 
 
@@ -112,8 +113,13 @@ class ReencryptTfaData extends Command
                  * its children.
                  */
                 $valueDecrypted = $this->recursiveDataProcessor->down($valueDecrypted);
-
+                // For test purposes
+                if (isset($valueDecrypted->google->secret)) {
+                    $nestedPlaintext = $this->encryptor->decrypt($valueDecrypted->google->secret);
+                    $output->writeln("nested_plaintext: $nestedPlaintext");
+                }
                 $valueDecrypted = json_encode($valueDecrypted);
+                $output->writeln("plaintext_new: " . $valueDecrypted);
                 $valueEncrypted = $this->encryptor->encrypt($valueDecrypted);
                 $output->writeln("ciphertext_new: " . $valueEncrypted);
 

--- a/Console/ReencryptTfaData.php
+++ b/Console/ReencryptTfaData.php
@@ -103,7 +103,7 @@ class ReencryptTfaData extends Command
                 $value = $row[$column];
                 $output->writeln("ciphertext_old: " . $value);
                 $valueDecrypted = $this->encryptor->decrypt($value);
-                $output->writeln("plaintext: " . $valueDecrypted);
+                $output->writeln("plaintext_old: " . $valueDecrypted);
                 $valueDecrypted = json_decode($valueDecrypted);
 
                 /**

--- a/Console/ReencryptTfaData.php
+++ b/Console/ReencryptTfaData.php
@@ -50,7 +50,7 @@ class ReencryptTfaData extends Command
             ),
         ];
 
-        $this->setName('gene:encryption-key-manager:reencrypt:tfa-data');
+        $this->setName('gene:encryption-key-manager:reencrypt-tfa-data');
         $this->setDescription('Re-encrypts tfa_user_config data with the latest key');
         $this->setDefinition($options);
 

--- a/Console/ReencryptTfaData.php
+++ b/Console/ReencryptTfaData.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+
+namespace Gene\EncryptionKeyManager\Console;
+
+use Gene\EncryptionKeyManager\Model\RecursiveDataProcessor;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Console\Cli;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReencryptTfaData extends Command
+{
+    public const INPUT_KEY_FORCE = 'force';
+
+    public const TFA_TABLE = 'tfa_user_config';
+
+    /**
+     * @param DeploymentConfig $deploymentConfig
+     * @param ResourceConnection $resourceConnection
+     * @param EncryptorInterface $encryptor
+     * @param CacheInterface $cache
+     * @param RecursiveDataProcessor $recursiveDataProcessor
+     */
+    public function __construct(
+        private readonly DeploymentConfig $deploymentConfig,
+        private readonly ResourceConnection $resourceConnection,
+        private readonly EncryptorInterface $encryptor,
+        private readonly CacheInterface $cache,
+        private readonly RecursiveDataProcessor $recursiveDataProcessor,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @return void
+     */
+    protected function configure()
+    {
+        $options = [
+            new InputOption(
+                self::INPUT_KEY_FORCE,
+                null,
+                InputOption::VALUE_NONE,
+                'Whether to force this action to take effect'
+            ),
+        ];
+
+        $this->setName('gene:encryption-key-manager:reencrypt:tfa-data');
+        $this->setDescription('Re-encrypts tfa_user_config data with the latest key');
+        $this->setDefinition($options);
+
+        parent::configure();
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$input->getOption(self::INPUT_KEY_FORCE)) {
+            $output->writeln('<info>Run with --force to make these changes, this will run in dry-run mode by default</info>');
+        }
+
+        $this->recursiveDataProcessor->processNestedEncryptedData();
+        try {
+            $keys = preg_split('/\s+/s', trim((string)$this->deploymentConfig->get('crypt/key')));
+            $latestKeyNumber = count($keys);// - 1;
+            $output->writeln("The latest encryption key is number $latestKeyNumber, looking for old entries");
+
+
+            $table = self::TFA_TABLE;
+            $identifier = 'config_id';
+            $column = 'encoded_config';
+            $output->writeln("Looking for $column in $table, identified by '$identifier'");
+
+            /**
+             * @see \Magento\Framework\Model\ResourceModel\Db\AbstractDb::_getLoadSelect()
+             */
+            $tableName = $this->resourceConnection->getTableName($table);
+            $connection = $this->resourceConnection->getConnection();
+            $field = $connection->quoteIdentifier(sprintf('%s.%s', $tableName, $column));
+
+            $select = $connection->select()
+                ->from($tableName, [$identifier, "$column"])
+                ->where("($field LIKE '_:_:____%' OR $field LIKE '__:_:____%')")
+                ->where("$field NOT LIKE ?", "$latestKeyNumber:_:__%");
+
+            $result = $connection->fetchAll($select);
+            if (empty($result)) {
+                $output->writeln('No old entries found');
+                return Cli::RETURN_SUCCESS;
+            }
+            $connection->beginTransaction();
+            foreach ($result as $row) {
+                $output->writeln(str_pad('', 120, '#'));
+                $output->writeln("$identifier: {$row[$identifier]}");
+                $value = $row[$column];
+                $output->writeln("ciphertext_old: " . $value);
+                $valueDecrypted = $this->encryptor->decrypt($value);
+                $output->writeln("plaintext: " . $valueDecrypted);
+                $valueDecrypted = json_decode($valueDecrypted);
+
+                /**
+                 * Google Authenticator 2FA provider uses a nested encrypted value. So that we can also handle other
+                 * providers that may do the same, recursively process the originally decrypted value, re-encrypting
+                 * its children.
+                 */
+                $valueDecrypted = $this->recursiveDataProcessor->down($valueDecrypted);
+
+                $valueDecrypted = json_encode($valueDecrypted);
+                $valueEncrypted = $this->encryptor->encrypt($valueDecrypted);
+                $output->writeln("ciphertext_new: " . $valueEncrypted);
+
+                if ($input->getOption(self::INPUT_KEY_FORCE)) {
+                    $connection->update(
+                        $tableName,
+                        [$column => $valueEncrypted],
+                        ["$identifier = ?" => $row[$identifier]]
+                    );
+                } else {
+                    $output->writeln('Dry run mode, no changes have been made');
+                }
+                $output->writeln(str_pad('', 120, '#'));
+            }
+
+            $connection->commit();
+            $this->cache->clean();
+            $output->writeln('Done');
+        } catch (\Throwable $throwable) {
+            if ($this->resourceConnection->getConnection()->getTransactionLevel() > 0) {
+                $this->resourceConnection->getConnection()->rollBack();
+            }
+            $output->writeln("<error>" . $throwable->getMessage() . "</error>");
+            $output->writeln($throwable->getTraceAsString(), OutputInterface::VERBOSITY_VERBOSE);
+            return Cli::RETURN_FAILURE;
+        }
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/Console/ReencryptTfaData.php
+++ b/Console/ReencryptTfaData.php
@@ -74,7 +74,6 @@ class ReencryptTfaData extends Command
             $latestKeyNumber = count($keys) - 1;
             $output->writeln("The latest encryption key is number $latestKeyNumber, looking for old entries");
 
-
             $table = self::TFA_TABLE;
             $identifier = 'config_id';
             $column = 'encoded_config';

--- a/Console/ReencryptTfaData.php
+++ b/Console/ReencryptTfaData.php
@@ -112,11 +112,6 @@ class ReencryptTfaData extends Command
                  * its children.
                  */
                 $valueDecrypted = $this->recursiveDataProcessor->down($valueDecrypted);
-                // For test purposes
-                if (isset($valueDecrypted->google->secret)) {
-                    $nestedPlaintext = $this->encryptor->decrypt($valueDecrypted->google->secret);
-                    $output->writeln("nested_plaintext: $nestedPlaintext");
-                }
                 $valueDecrypted = json_encode($valueDecrypted);
                 $output->writeln("plaintext_new: " . $valueDecrypted);
                 $valueEncrypted = $this->encryptor->encrypt($valueDecrypted);

--- a/Console/ReencryptTfaData.php
+++ b/Console/ReencryptTfaData.php
@@ -133,7 +133,9 @@ class ReencryptTfaData extends Command
                 }
                 $output->writeln(str_pad('', 120, '#'));
             }
-
+            if ($this->recursiveDataProcessor->hasFailures()) {
+                $output->writeln('<error>We encountered some problems re-encrypting values in the tfa_user_config table which requires manual intervention</error>');
+            }
             $connection->commit();
             $this->cache->clean();
             $output->writeln('Done');

--- a/Model/RecursiveDataProcessor.php
+++ b/Model/RecursiveDataProcessor.php
@@ -6,13 +6,17 @@ use Magento\Framework\Encryption\EncryptorInterface;
 
 class RecursiveDataProcessor
 {
+    /**
+     * @param EncryptorInterface $encryptor
+     */
     public function __construct(
         private readonly EncryptorInterface $encryptor,
-    ) {}
+    ) {
+    }
 
     /**
      * Recursively process nested encrypted values
-     * @param $layer
+     * @param mixed $layer
      * @return mixed
      */
     public function down($layer)
@@ -44,9 +48,10 @@ class RecursiveDataProcessor
 
     /**
      * Wrapper to set value back to parent as element write syntax differs by type
-     * @param $parent
-     * @param $key
-     * @param $value
+     *
+     * @param mixed $parent
+     * @param mixed $key
+     * @param mixed $value
      * @return mixed
      */
     private function setValue($parent, $key, $value)

--- a/Model/RecursiveDataProcessor.php
+++ b/Model/RecursiveDataProcessor.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Gene\EncryptionKeyManager\Model;
+
+use Magento\Framework\Encryption\EncryptorInterface;
+
+class RecursiveDataProcessor
+{
+    public function __construct(
+        private readonly EncryptorInterface $encryptor,
+    ) {}
+
+    /**
+     * Recursively process nested encrypted values
+     * @param $layer
+     * @return mixed
+     */
+    public function down($layer)
+    {
+        foreach ($layer as $key => $value) {
+            if (is_array($value) || is_object($value)) {
+                // If either array or object go down a level and process it and its children
+                $value = $this->down($value);
+            } else {
+                // Only need to process encrypted strings
+                if (is_string($value)) {
+                    // Previous iteration may have $matches so unset
+                    unset($matches);
+                    // Match on string that look encrypted (digit:digit:non_whitespace(1 or more)
+                    preg_match('/\d:\d:\S+/', $value, $matches);
+                    // If match found $matches[0] will exist
+                    if (isset($matches[0])) {
+                        // Re-encrypt value
+                        $value = $this->encryptor->decrypt($value);
+                        $value = $this->encryptor->encrypt($value);
+                    }
+                }
+            }
+            // Set value back to parent
+            $this->setValue($layer, $key, $value);
+        }
+        return $layer;
+    }
+
+    /**
+     * Wrapper to set value back to parent as element write syntax differs by type
+     * @param $parent
+     * @param $key
+     * @param $value
+     * @return mixed
+     */
+    private function setValue($parent, $key, $value)
+    {
+        if (is_array($parent)) {
+            $parent[$key] = $value;
+        } else {
+            // $parent is object
+            $parent->$key = $value;
+        }
+        return $parent;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# module-encryption-key-manager
+[# module-encryption-key-manager
 
 [![<genecommerce>](https://circleci.com/gh/genecommerce/module-encryption-key-manager.svg?style=svg)](https://circleci.com/gh/genecommerce/module-encryption-key-manager)
 
@@ -57,6 +57,8 @@ adobe_user_profile
    1. `Magento\JwtUserToken\Model\SecretBasedJwksFactory` will only use the most recently generated key at the highest index
 4. **Fix missing config values** `php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data`
    1. Re-run to verify `php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data`
+4. **Fix 2FA data** `php bin/magento gene:encryption-key-manager:reencrypt-tfa-data`
+   1. Re-run to verify `php bin/magento gene:encryption-key-manager:reencrypt-tfa-data`
 5. Fix up all additional identified columns like so, be careful to verify each table and column as this may not be an exhaustive list (also be aware of `entity_id`, `row_id` and `id`)
     1. `bin/magento gene:encryption-key-manager:reencrypt-column admin_user user_id rp_token`
     2. `bin/magento gene:encryption-key-manager:reencrypt-column customer_entity entity_id rp_token`
@@ -197,3 +199,27 @@ Dry run mode, no changes have been made
 Done
 ```
 
+## bin/magento gene:encryption-key-manager:reencrypt-tfa-data
+
+This command re-encrypts the 2FA data stored in `tfa_user_config`. Some of this data is doubly encrypted, which is why it needs special handling. 
+
+This command runs in dry run mode by default, do that as a first pass to see the changes that will be made. When you are happy run with `--force`.
+
+This CLI has only been tested with Google Authenticator (TOTP) and U2F (Yubikey, etc). If you use Authy or DUO you *MUST* verify before use.
+
+```bash
+$ bin/magento gene:encryption-key-manager:reencrypt-tfa-data
+Run with --force to make these changes, this will run in dry-run mode by default
+This CLI has only been tested with Google Authenticator (TOTP) and U2F (Yubikey, etc). If you use Authy or DUO you *MUST* verify before use.
+The latest encryption key is number 1, looking for old entries
+Looking for encoded_config in tfa_user_config, identified by 'config_id'
+########################################################################################################################
+config_id: 1
+ciphertext_old: 0:3:rV/z9+ilmOtaPGnOoZBayZ3waBNphK1RAcyWLetipM5UONn793rTyRknO1GhWxKxXC3ooJAgWDTMJPaXGRMGdj8yOqrlrjEp9uqi8D9SFgE/UTiWkBF4RRwVvZeo4lGGnll/CxJmtzuMXWa65TS0Z/a2QLdPyIH/3OomJH7sb3FgfQ==
+plaintext: {"google":{"secret":"0:3:LKm9642Rpl0gqlBha+m3FYWnQBBtLgjdLDvjfoPo923xmxd9ykbnvX0LucKI","active":true}}
+plaintext_new: {"google":{"secret":"1:3:m9mScDkTkeCdn2lXpwf5oMkL7lmgLOTYJXQyKbK\/m8QwDZVDNWI3CzH+uBaq","active":true}}
+ciphertext_new: 1:3:Tw/5ik2meBqzL8oodrudxmksrOekA/DbZE5+KgBAygFxp6Zx/A7vbMyHt4+N1MtQhlnqW/mAXL3l2kDpFHIQVvi2L+23o9mRpii2ldBwmuZgDlpQsm+Q4Hf8a+t2aUKndGOMeoH6xcZXFCConC+TUI+uregFXx6B5LU4ohCY52m/v7w=
+Dry run mode, no changes have been made
+########################################################################################################################
+Done
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[# module-encryption-key-manager
+# module-encryption-key-manager
 
 [![<genecommerce>](https://circleci.com/gh/genecommerce/module-encryption-key-manager.svg?style=svg)](https://circleci.com/gh/genecommerce/module-encryption-key-manager)
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Looking for encoded_config in tfa_user_config, identified by 'config_id'
 ########################################################################################################################
 config_id: 1
 ciphertext_old: 0:3:rV/z9+ilmOtaPGnOoZBayZ3waBNphK1RAcyWLetipM5UONn793rTyRknO1GhWxKxXC3ooJAgWDTMJPaXGRMGdj8yOqrlrjEp9uqi8D9SFgE/UTiWkBF4RRwVvZeo4lGGnll/CxJmtzuMXWa65TS0Z/a2QLdPyIH/3OomJH7sb3FgfQ==
-plaintext: {"google":{"secret":"0:3:LKm9642Rpl0gqlBha+m3FYWnQBBtLgjdLDvjfoPo923xmxd9ykbnvX0LucKI","active":true}}
+plaintext_old: {"google":{"secret":"0:3:LKm9642Rpl0gqlBha+m3FYWnQBBtLgjdLDvjfoPo923xmxd9ykbnvX0LucKI","active":true}}
 plaintext_new: {"google":{"secret":"1:3:m9mScDkTkeCdn2lXpwf5oMkL7lmgLOTYJXQyKbK\/m8QwDZVDNWI3CzH+uBaq","active":true}}
 ciphertext_new: 1:3:Tw/5ik2meBqzL8oodrudxmksrOekA/DbZE5+KgBAygFxp6Zx/A7vbMyHt4+N1MtQhlnqW/mAXL3l2kDpFHIQVvi2L+23o9mRpii2ldBwmuZgDlpQsm+Q4Hf8a+t2aUKndGOMeoH6xcZXFCConC+TUI+uregFXx6B5LU4ohCY52m/v7w=
 Dry run mode, no changes have been made

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -38,7 +38,6 @@ php bin/magento gene:encryption-key-manager:generate > test.txt || true;
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: generate needs to run with force"
 else
-    cat test.txt
     echo "FAIL: generate needs to run with force" && false
 fi
 
@@ -46,7 +45,6 @@ php bin/magento gene:encryption-key-manager:invalidate > test.txt || true
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: invalidate needs to run with force"
 else
-    cat test.txt
     echo "FAIL: invalidate needs to run with force" && false
 fi
 
@@ -54,7 +52,6 @@ php bin/magento gene:encryption-key-manager:reencrypt-unhandled-core-config-data
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: reencrypt-unhandled-core-config-data needs to run with force"
 else
-    cat test.txt
     echo "FAIL: reencrypt-unhandled-core-config-data needs to run with force" && false
 fi
 
@@ -62,7 +59,6 @@ php bin/magento gene:encryption-key-manager:reencrypt-tfa-data > test.txt || tru
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: reencrypt-tfa-data needs to run with force"
 else
-    cat test.txt
     echo "FAIL: reencrypt-tfa-data needs to run with force" && false
 fi
 
@@ -70,7 +66,6 @@ php bin/magento gene:encryption-key-manager:reencrypt-column admin_user user_id 
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: reencrypt-column needs to run with force"
 else
-    cat test.txt
     echo "FAIL: reencrypt-column needs to run with force" && false
 fi
 echo "";echo "";
@@ -80,7 +75,6 @@ php bin/magento gene:encryption-key-manager:invalidate --force > test.txt || tru
 if grep -Eq 'Cannot invalidate when there is only one key|No further keys need invalidated' test.txt; then
     echo "PASS: You cannot invalidate with only 1 key"
 else
-    cat test.txt
     echo "FAIL" && false
 fi
 echo "";echo "";
@@ -106,8 +100,7 @@ echo "Running reencrypt-tfa-data"
 php bin/magento gene:encryption-key-manager:reencrypt-tfa-data --force > test.txt
 cat test.txt
 grep 'plaintext_new' test.txt | grep 'secret' test.txt
-if grep -q 'plaintext_new' "$TWOFA_JSON_ENCRYPTED" test.txt; then
-    cat test.txt
+if grep 'plaintext_new' test.txt | grep "$TWOFA_JSON_ENCRYPTED"; then
     echo "FAIL: The plaintext_new should no longer have the original TWOFA_JSON_ENCRYPTED data" && false
 else
     echo "PASS: The plaintext_new should no longer have the original TWOFA_JSON_ENCRYPTED data"

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -46,6 +46,14 @@ else
     echo "FAIL: reencrypt-unhandled-core-config-data needs to run with force" && false
 fi
 
+php bin/magento gene:encryption-key-manager:reencrypt-tfa-data > test.txt || true
+if grep -q 'Run with --force' test.txt; then
+    echo "PASS: reencrypt-tfa-data needs to run with force"
+else
+    cat test.txt
+    echo "FAIL: reencrypt-tfa-data needs to run with force" && false
+fi
+
 php bin/magento gene:encryption-key-manager:reencrypt-column admin_user user_id rp_token > test.txt || true
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: reencrypt-column needs to run with force"

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -20,7 +20,10 @@ ADMIN_ID="${ADMIN_ID: -1}"
 FAKE_GOOGLE_TOKEN=$(vendor/bin/n98-magerun2 dev:encrypt 'googletokenabc123')
 TWOFA_JSON="{\"google\":{\"secret\":\"$FAKE_GOOGLE_TOKEN\",\"active\":true}}"
 TWOFA_JSON_ENCRYPTED=$(vendor/bin/n98-magerun2 dev:encrypt "$TWOFA_JSON")
-
+echo "Generating 2FA data for admin user $ADMIN in tfa_user_config"
+vendor/bin/n98-magerun2 db:query "delete from tfa_user_config where user_id=$ADMIN_ID";
+vendor/bin/n98-magerun2 db:query "insert into tfa_user_config(user_id, encoded_config) values ($ADMIN_ID, '$TWOFA_JSON_ENCRYPTED');"
+vendor/bin/n98-magerun2 db:query "select user_id, encoded_config from tfa_user_config where user_id=$ADMIN_ID";
 FAKE_RP_TOKEN=$(vendor/bin/n98-magerun2 dev:encrypt 'abc123')
 vendor/bin/n98-magerun2 db:query "update admin_user set rp_token='$FAKE_RP_TOKEN' where username='$ADMIN'"
 echo "Generated FAKE_RP_TOKEN=$FAKE_RP_TOKEN and assigned to $ADMIN"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -32,6 +32,7 @@
                 <item name="gene_encryption_key_invalidate" xsi:type="object">Gene\EncryptionKeyManager\Console\InvalidateOldEncryptionKeys</item>
                 <item name="gene_encryption_key_reencrypt" xsi:type="object">Gene\EncryptionKeyManager\Console\ReencryptUnhandledCoreConfigData</item>
                 <item name="gene_encryption_key_reencryptcolumn" xsi:type="object">Gene\EncryptionKeyManager\Console\ReencryptColumn</item>
+                <item name="gene_encryption_key_reencrypt_tfa" xsi:type="object">Gene\EncryptionKeyManager\Console\ReencryptTfaData</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Fixes #8 
# Summary
- CLI command to re-encrypt values in the tfa_user_config table based on  https://github.com/genecommerce/module-encryption-key-manager/blob/master/Console/ReencryptColumn.php,
- I have commented `Model/RecursiveDataProcessor.php` more than normal purely due to the fact it's recursive so wanted to add more verbose overview of whats happening.
- Opened as draft for reviews/feedback whilst I continue testing/validating my changes

## Example output

The 2FA details can contain encrypted data within a json payload, which is also encrypted. So we navigate down and decrypt those values.

```
Running reencrypt-tfa-data
The latest encryption key is number 1, looking for old entries
Looking for encoded_config in tfa_user_config, identified by 'config_id'
########################################################################################################################
config_id: 1
ciphertext_old: 0:3:VYVmpwkM1mhg5qh0pX1fJg8kV9rWlWr7Q/aOl4CtbdHXaSOyPUJ7L92J8/JlwE86kAKiyAsXgztqBNqdbd6+Ct3z0vGAzguwe63rtjfhRffYzXwhugdTdDt4ov8lpfci66N86dSQddNdLJ+orrPgMNIf2daUFZMbPyviWkCnPGq/CA==
plaintext_old: {"google":{"secret":"0:3:k+zKqK36ipT7v9fff0bWTLBk1/OtYNHHizMUyZGAk2KyWcSFPFz+FKIdJQyy","active":true}}
plaintext_new: {"google":{"secret":"1:3:BW\/UG73qg8O9oqRqQJ3hqAW7YRuK1f+xoXFuxs46vaCytH3xqpsd8ADrqRsU","active":true}}
ciphertext_new: 1:3:ISY01PTteJ9wJkMjvEfbwNxtoMXeLz96y67yP5FkiDUAaznkz7/1J5yFQCsjs7LTuonEKrIZG8hIrPOf1qc/O6cajRcxdu3WzSe7qYMKErXIkhyvoKBmBTrnrVhgbQccsYp/FMBvhQPcUqiDXpShQVDPMFRT2q7Ray2KXjdvMdwRERs=
########################################################################################################################
Done
```