### PR TITLE
Add `--skip-saved-credit-cards` to `generate`

### DIFF
--- a/Console/GenerateEncryptionKey.php
+++ b/Console/GenerateEncryptionKey.php
@@ -18,6 +18,7 @@ use Magento\Framework\App\State;
 class GenerateEncryptionKey extends Command
 {
     public const INPUT_KEY_FORCE = 'force';
+    public const INPUT_SKIP_SAVED_CREDIT_CARDS = 'skip-saved-credit-cards';
     public const INPUT_KEY_KEY = 'key';
     public const INPUT_KEY_KEY_SHORTCUT = 'k';
 
@@ -53,6 +54,12 @@ class GenerateEncryptionKey extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Whether to force this action to take effect'
+            ),
+            new InputOption(
+                self::INPUT_SKIP_SAVED_CREDIT_CARDS,
+                null,
+                InputOption::VALUE_NONE,
+                'Whether to skip encrypting the sales_order_payment cc_number_enc data'
             ),
             new InputOption(
                 self::INPUT_KEY_KEY,
@@ -102,6 +109,9 @@ class GenerateEncryptionKey extends Command
             $this->emulation->startEnvironmentEmulation(0, 'adminhtml');
             $output->writeln('Generating a new encryption key using the magento core class');
             $this->changeEncryptionKey->setOutput($output);
+            $this->changeEncryptionKey->setSkipSavedCreditCards(
+                (bool)$input->getOption(self::INPUT_SKIP_SAVED_CREDIT_CARDS)
+            );
             $this->changeEncryptionKey->changeEncryptionKey($newKey);
             $this->emulation->stopEnvironmentEmulation();
             $output->writeln('Cleaning cache');

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ This is a rough list of steps that should be followed to prevent attacks with Co
 
 This should be every merchant's **priority!** Install this module and generate a new key with: 
 
-`php bin/magento gene:encryption-key-manager:generate [--key=MY_32_CHAR_CRYPT_KEY]`
+`php bin/magento gene:encryption-key-manager:generate [--key=MY_32_CHAR_CRYPT_KEY] [--skip-saved-credit-cards]`
 
 This will force the JWT factory to use the newly generated key. Other areas of the application may continue to use the old keys. This step is the absolute priority and will help prevent attacks with CosmicSting.
 
-> Use the `--key` option to manually define the new key to use during re-encryption. If no custom key is provided, a new key will be generated.
+- Use the `--key` option to manually define the new key to use during re-encryption. If no custom key is provided, a new key will be generated.
+- Use the `--skip-saved-credit-cards` flag to skip re-encrypting the `sales_order_payment` `cc_number_enc` data. This table can be very large, and many stores will have no data saved in this column.
 
 ## Fully rotate your old keys
 
@@ -129,6 +130,9 @@ _reEncryptCreditCardNumbers - end
 Cleaning cache
 Done
 ```
+
+- Use the `--key` option to manually define the new key to use during re-encryption. If no custom key is provided, a new key will be generated.
+- Use the `--skip-saved-credit-cards` flag to skip re-encrypting the `sales_order_payment` `cc_number_enc` data. This table can be very large, and many stores will have no data saved in this column.
 
 ## bin/magento gene:encryption-key-manager:invalidate
 

--- a/Service/ChangeEncryptionKey.php
+++ b/Service/ChangeEncryptionKey.php
@@ -10,6 +10,9 @@ class ChangeEncryptionKey extends MageChanger
     /** @var OutputInterface|null */
     private $output;
 
+    /** @var bool  */
+    private $skipSavedCreditCards = false;
+
     /**
      * @param OutputInterface $output
      * @return void
@@ -17,6 +20,15 @@ class ChangeEncryptionKey extends MageChanger
     public function setOutput(OutputInterface $output)
     {
         $this->output = $output;
+    }
+
+    /**
+     * @param bool $skipSavedCreditCards
+     * @return void
+     */
+    public function setSkipSavedCreditCards($skipSavedCreditCards)
+    {
+        $this->skipSavedCreditCards = (bool) $skipSavedCreditCards;
     }
 
     /**
@@ -51,6 +63,10 @@ class ChangeEncryptionKey extends MageChanger
      */
     protected function _reEncryptCreditCardNumbers()
     {
+        if ($this->skipSavedCreditCards) {
+            $this->writeOutput('_reEncryptCreditCardNumbers - skipping');
+            return;
+        }
         $this->writeOutput('_reEncryptCreditCardNumbers - start');
         $table = $this->getTable('sales_order_payment');
         $select = $this->getConnection()->select()->from($table, ['entity_id', 'cc_number_enc']);

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -80,7 +80,25 @@ fi
 echo "";echo "";
 
 echo "Generating a new encryption key"
-php bin/magento gene:encryption-key-manager:generate --force
+php bin/magento gene:encryption-key-manager:generate --force  > test.txt
+grep -q '_reEncryptSystemConfigurationValues - start' test.txt
+grep -q '_reEncryptSystemConfigurationValues - end'   test.txt
+grep -q '_reEncryptCreditCardNumbers - start' test.txt
+grep -q '_reEncryptCreditCardNumbers - end'   test.txt
+echo "PASS"
+echo "";echo "";
+
+echo "Generating a new encryption key - skipping _reEncryptCreditCardNumbers"
+php bin/magento gene:encryption-key-manager:generate --force --skip-saved-credit-cards > test.txt
+grep -q '_reEncryptSystemConfigurationValues - start' test.txt
+grep -q '_reEncryptSystemConfigurationValues - end'   test.txt
+grep -q '_reEncryptCreditCardNumbers - skipping' test.txt
+if grep -q '_reEncryptCreditCardNumbers - start' test.txt; then
+    echo "FAIL: We should never start on _reEncryptCreditCardNumbers with --skip-saved-credit-cards" && false
+fi
+if grep -q '_reEncryptCreditCardNumbers - end' test.txt; then
+    echo "FAIL: We should never end on _reEncryptCreditCardNumbers with --skip-saved-credit-cards" && false
+fi
 echo "PASS"
 echo "";echo "";
 


### PR DESCRIPTION
From @braders in https://github.com/genecommerce/module-encryption-key-manager/issues/9#issuecomment-2243013706

> I am working on a site with around 2.5 million records in the sales_order_payment table, and am wary to try loading that into memory.
>
>We don't support saved card numbers, and so cc_number_enc is always empty. It'd be nice to have the possibility to skip running the _reEncryptCreditCardNumbers function.

