### PR TITLE
Fix "Area code is already set" error

### DIFF
--- a/Console/GenerateEncryptionKey.php
+++ b/Console/GenerateEncryptionKey.php
@@ -105,7 +105,11 @@ class GenerateEncryptionKey extends Command
              *
              * @see \Magento\EncryptionKey\Controller\Adminhtml\Crypt\Key\Save::execute()
              */
-            $this->state->setAreaCode('adminhtml');
+            try {
+                $this->state->setAreaCode('adminhtml');
+            } catch (\Magento\Framework\Exception\LocalizedException $exception) {
+                // Area code is already set
+            }
             $this->emulation->startEnvironmentEmulation(0, 'adminhtml');
             $output->writeln('Generating a new encryption key using the magento core class');
             $this->changeEncryptionKey->setOutput($output);


### PR DESCRIPTION
I am getting "Area code is already set" on my installation. This fix catches the exception and allows the process to continue on.