### PR TITLE
Added re-encryption functionality for env.php  (#30 plus test)

### DIFF
--- a/Console/GenerateEncryptionKey.php
+++ b/Console/GenerateEncryptionKey.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace Gene\EncryptionKeyManager\Console;
 
 use Gene\EncryptionKeyManager\Service\ChangeEncryptionKey as ChangeEncryptionKeyService;
+use Gene\EncryptionKeyManager\Service\ReencryptEnvSystemConfigurationValues;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\Encryption\Encryptor;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -38,7 +39,8 @@ class GenerateEncryptionKey extends Command
         private readonly WriterInterface $configWriter,
         private readonly Emulation $emulation,
         private readonly State $state,
-        private readonly Encryptor $encryptor
+        private readonly Encryptor $encryptor,
+        private readonly ReencryptEnvSystemConfigurationValues $reencryptEnvSystemConfigurationValues
     ) {
         parent::__construct();
     }
@@ -113,7 +115,9 @@ class GenerateEncryptionKey extends Command
                 (bool)$input->getOption(self::INPUT_SKIP_SAVED_CREDIT_CARDS)
             );
             $this->changeEncryptionKey->changeEncryptionKey($newKey);
-            $this->changeEncryptionKey->reEncryptEnvConfigurationValues();
+            $output->writeln('reEncryptEnvConfigurationValues - start');
+            $this->reencryptEnvSystemConfigurationValues->execute();
+            $output->writeln('reEncryptEnvConfigurationValues - end');
             $this->emulation->stopEnvironmentEmulation();
             $output->writeln('Cleaning cache');
 

--- a/Console/GenerateEncryptionKey.php
+++ b/Console/GenerateEncryptionKey.php
@@ -113,6 +113,7 @@ class GenerateEncryptionKey extends Command
                 (bool)$input->getOption(self::INPUT_SKIP_SAVED_CREDIT_CARDS)
             );
             $this->changeEncryptionKey->changeEncryptionKey($newKey);
+            $this->changeEncryptionKey->reEncryptEnvConfigurationValues();
             $this->emulation->stopEnvironmentEmulation();
             $output->writeln('Cleaning cache');
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Done
 
 - Use the `--key` option to manually define the new key to use during re-encryption. If no custom key is provided, a new key will be generated.
 - Use the `--skip-saved-credit-cards` flag to skip re-encrypting the `sales_order_payment` `cc_number_enc` data. This table can be very large, and many stores will have no data saved in this column.
+- This will automatically re-encrypt any `system` values in `app/etc/env.php`
 
 ## bin/magento gene:encryption-key-manager:invalidate
 

--- a/Service/ChangeEncryptionKey.php
+++ b/Service/ChangeEncryptionKey.php
@@ -86,10 +86,6 @@ class ChangeEncryptionKey extends MageChanger
         $this->writeOutput('_reEncryptSystemConfigurationValues - start');
         parent::_reEncryptSystemConfigurationValues();
         $this->writeOutput('_reEncryptSystemConfigurationValues - end');
-
-        $this->writeOutput('_reEncryptEnvConfigurationValues - start');
-        $this->_reEncryptEnvConfigurationValues();
-        $this->writeOutput('_reEncryptEnvConfigurationValues - end');
     }
 
     /**
@@ -133,14 +129,16 @@ class ChangeEncryptionKey extends MageChanger
      * @throws FileSystemException
      * @throws RuntimeException
      */
-    protected function _reEncryptEnvConfigurationValues()
+    public function reEncryptEnvConfigurationValues(): void
     {
+        $this->writeOutput('_reEncryptEnvConfigurationValues - start');
         $systemConfig = $this->deploymentConfig->get('system');
         $systemConfig = $this->iterateSystemConfig($systemConfig);
 
         $encryptSegment = new ConfigData(ConfigFilePool::APP_ENV);
         $encryptSegment->set('system', $systemConfig);
         $this->writer->saveConfig([$encryptSegment->getFileKey() => $encryptSegment->getData()]);
+        $this->writeOutput('_reEncryptEnvConfigurationValues - end');
     }
 
     /**
@@ -150,7 +148,7 @@ class ChangeEncryptionKey extends MageChanger
      * @return array
      * @throws \Exception
      */
-    private function iterateSystemConfig(array $systemConfig)
+    private function iterateSystemConfig(array $systemConfig): array
     {
         foreach ($systemConfig as $key => &$value) {
             if (is_array($value)) {

--- a/Service/ChangeEncryptionKey.php
+++ b/Service/ChangeEncryptionKey.php
@@ -131,14 +131,14 @@ class ChangeEncryptionKey extends MageChanger
      */
     public function reEncryptEnvConfigurationValues(): void
     {
-        $this->writeOutput('_reEncryptEnvConfigurationValues - start');
+        $this->writeOutput('reEncryptEnvConfigurationValues - start');
         $systemConfig = $this->deploymentConfig->get('system');
         $systemConfig = $this->iterateSystemConfig($systemConfig);
 
         $encryptSegment = new ConfigData(ConfigFilePool::APP_ENV);
         $encryptSegment->set('system', $systemConfig);
         $this->writer->saveConfig([$encryptSegment->getFileKey() => $encryptSegment->getData()]);
-        $this->writeOutput('_reEncryptEnvConfigurationValues - end');
+        $this->writeOutput('reEncryptEnvConfigurationValues - end');
     }
 
     /**

--- a/Service/ChangeEncryptionKey.php
+++ b/Service/ChangeEncryptionKey.php
@@ -2,18 +2,7 @@
 declare(strict_types=1);
 namespace Gene\EncryptionKeyManager\Service;
 
-use Magento\Config\Model\Config\Structure;
 use Magento\EncryptionKey\Model\ResourceModel\Key\Change as MageChanger;
-use Magento\Framework\App\DeploymentConfig;
-use Magento\Framework\App\DeploymentConfig\Writer;
-use Magento\Framework\Config\Data\ConfigData;
-use Magento\Framework\Config\File\ConfigFilePool;
-use Magento\Framework\Encryption\EncryptorInterface;
-use Magento\Framework\Exception\FileSystemException;
-use Magento\Framework\Exception\RuntimeException;
-use Magento\Framework\Filesystem;
-use Magento\Framework\Math\Random;
-use Magento\Framework\Model\ResourceModel\Db\Context;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ChangeEncryptionKey extends MageChanger
@@ -23,29 +12,6 @@ class ChangeEncryptionKey extends MageChanger
 
     /** @var bool  */
     private $skipSavedCreditCards = false;
-
-    /**
-     * @param Context $context
-     * @param Filesystem $filesystem
-     * @param Structure $structure
-     * @param EncryptorInterface $encryptor
-     * @param Writer $writer
-     * @param Random $random
-     * @param DeploymentConfig $deploymentConfig
-     * @param $connectionName
-     */
-    public function __construct(
-        Context $context,
-        Filesystem $filesystem,
-        Structure $structure,
-        EncryptorInterface $encryptor,
-        Writer $writer,
-        Random $random,
-        private readonly DeploymentConfig $deploymentConfig,
-        $connectionName = null,
-    ) {
-        parent::__construct($context, $filesystem, $structure, $encryptor, $writer, $random, $connectionName);
-    }
 
     /**
      * @param OutputInterface $output
@@ -120,44 +86,5 @@ class ChangeEncryptionKey extends MageChanger
             );
         }
         $this->writeOutput('_reEncryptCreditCardNumbers - end');
-    }
-
-    /**
-     * Gather all encrypted system config values from env.php and re-encrypt them
-     *
-     * @return void
-     * @throws FileSystemException
-     * @throws RuntimeException
-     */
-    public function reEncryptEnvConfigurationValues(): void
-    {
-        $this->writeOutput('reEncryptEnvConfigurationValues - start');
-        $systemConfig = $this->deploymentConfig->get('system');
-        $systemConfig = $this->iterateSystemConfig($systemConfig);
-
-        $encryptSegment = new ConfigData(ConfigFilePool::APP_ENV);
-        $encryptSegment->set('system', $systemConfig);
-        $this->writer->saveConfig([$encryptSegment->getFileKey() => $encryptSegment->getData()]);
-        $this->writeOutput('reEncryptEnvConfigurationValues - end');
-    }
-
-    /**
-     * Recursively iterate through the system configuration and re-encrypt any encrypted values
-     *
-     * @param array $systemConfig
-     * @return array
-     * @throws \Exception
-     */
-    private function iterateSystemConfig(array $systemConfig): array
-    {
-        foreach ($systemConfig as $key => &$value) {
-            if (is_array($value)) {
-                $value = $this->iterateSystemConfig($value);
-            } elseif (is_string($value) && preg_match('/^\d+:\d+:.*$/', $value)) {
-                $value = $this->encryptor->encrypt($this->encryptor->decrypt($value));
-            }
-        }
-
-        return $systemConfig;
     }
 }

--- a/Service/ReencryptEnvSystemConfigurationValues.php
+++ b/Service/ReencryptEnvSystemConfigurationValues.php
@@ -8,21 +8,25 @@ use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\Config\Data\ConfigData;
 use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Encryption\EncryptorInterfaceFactory;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\RuntimeException;
 
 class ReencryptEnvSystemConfigurationValues
 {
+    /** @var EncryptorInterface|null  */
+    private $encryptor = null;
+
     /**
      * @param DeploymentConfig $deploymentConfig
      * @param Writer $writer
-     * @param EncryptorInterface $encryptor
+     * @param EncryptorInterfaceFactory $encryptorFactory
      */
     public function __construct(
         private readonly DeploymentConfig $deploymentConfig,
         private readonly Writer $writer,
-        private readonly EncryptorInterface $encryptor
+        private readonly EncryptorInterfaceFactory $encryptorFactory
     ) {
     }
 
@@ -36,6 +40,8 @@ class ReencryptEnvSystemConfigurationValues
      */
     public function execute(): void
     {
+        $this->deploymentConfig->resetData();
+        $this->encryptor = $this->encryptorFactory->create();
         $systemConfig = $this->deploymentConfig->get('system');
         $systemConfig = $this->iterateSystemConfig($systemConfig);
 

--- a/Service/ReencryptEnvSystemConfigurationValues.php
+++ b/Service/ReencryptEnvSystemConfigurationValues.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gene\EncryptionKeyManager\Service;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\Config\Data\ConfigData;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\RuntimeException;
+
+class ReencryptEnvSystemConfigurationValues
+{
+    /**
+     * @param DeploymentConfig $deploymentConfig
+     * @param Writer $writer
+     * @param EncryptorInterface $encryptor
+     */
+    public function __construct(
+        private readonly DeploymentConfig $deploymentConfig,
+        private readonly Writer $writer,
+        private readonly EncryptorInterface $encryptor
+    ) {
+    }
+
+    /**
+     * Gather all encrypted system config values from env.php and re-encrypt them
+     *
+     * @return void
+     * @throws FileSystemException
+     * @throws RuntimeException
+     * @throws \Exception
+     */
+    public function execute(): void
+    {
+        $systemConfig = $this->deploymentConfig->get('system');
+        $systemConfig = $this->iterateSystemConfig($systemConfig);
+
+        $encryptSegment = new ConfigData(ConfigFilePool::APP_ENV);
+        $encryptSegment->set('system', $systemConfig);
+        $this->writer->saveConfig([$encryptSegment->getFileKey() => $encryptSegment->getData()]);
+    }
+
+    /**
+     * Recursively iterate through the system configuration and re-encrypt any encrypted values
+     *
+     * @param array $systemConfig
+     * @return array
+     * @throws \Exception
+     */
+    private function iterateSystemConfig(array $systemConfig): array
+    {
+        foreach ($systemConfig as $key => &$value) {
+            if (is_array($value)) {
+                $value = $this->iterateSystemConfig($value);
+            } elseif (is_string($value) && preg_match('/^\d+:\d+:.*$/', $value)) {
+                $value = $this->encryptor->encrypt($this->encryptor->decrypt($value));
+            }
+        }
+
+        return $systemConfig;
+    }
+}

--- a/Service/ReencryptEnvSystemConfigurationValues.php
+++ b/Service/ReencryptEnvSystemConfigurationValues.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gene\EncryptionKeyManager\Service;
 
+use Magento\Deploy\Model\DeploymentConfig\Hash;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\Config\Data\ConfigData;
@@ -22,11 +23,13 @@ class ReencryptEnvSystemConfigurationValues
      * @param DeploymentConfig $deploymentConfig
      * @param Writer $writer
      * @param EncryptorInterfaceFactory $encryptorFactory
+     * @param Hash $hash
      */
     public function __construct(
         private readonly DeploymentConfig $deploymentConfig,
         private readonly Writer $writer,
-        private readonly EncryptorInterfaceFactory $encryptorFactory
+        private readonly EncryptorInterfaceFactory $encryptorFactory,
+        private readonly Hash $hash
     ) {
     }
 
@@ -48,6 +51,11 @@ class ReencryptEnvSystemConfigurationValues
         $encryptSegment = new ConfigData(ConfigFilePool::APP_ENV);
         $encryptSegment->set('system', $systemConfig);
         $this->writer->saveConfig([$encryptSegment->getFileKey() => $encryptSegment->getData()]);
+
+        /**
+         * @see \Magento\Deploy\Console\Command\App\ConfigImport\Processor::execute()
+         */
+        $this->hash->regenerate('system');
     }
 
     /**

--- a/Service/ReencryptEnvSystemConfigurationValues.php
+++ b/Service/ReencryptEnvSystemConfigurationValues.php
@@ -57,7 +57,10 @@ class ReencryptEnvSystemConfigurationValues
             if (is_array($value)) {
                 $value = $this->iterateSystemConfig($value);
             } elseif (is_string($value) && preg_match('/^\d+:\d+:.*$/', $value)) {
-                $value = $this->encryptor->encrypt($this->encryptor->decrypt($value));
+                $decryptedValue = $this->encryptor->decrypt($value);
+                if ($decryptedValue) {
+                    $value = $this->encryptor->encrypt($decryptedValue);
+                }
             }
         }
 

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -92,7 +92,7 @@ php bin/magento gene:encryption-key-manager:generate --force  > test.txt
 if grep -q "$ENCRYPTED_ENV_VALUE" app/etc/env.php; then
     echo "FAIL: The old encrypted value in env.php was not updated" && false
 fi
-grep -q "'name'" app/etc/env.php | grep "1:3:"
+grep "'name'" app/etc/env.php | grep -q "1:3:"
 grep -q '_reEncryptSystemConfigurationValues - start' test.txt
 grep -q '_reEncryptSystemConfigurationValues - end'   test.txt
 grep -q '_reEncryptCreditCardNumbers - start' test.txt
@@ -102,7 +102,7 @@ echo "";echo "";
 
 echo "Generating a new encryption key - skipping _reEncryptCreditCardNumbers"
 php bin/magento gene:encryption-key-manager:generate --force --skip-saved-credit-cards > test.txt
-grep -q "'name'" app/etc/env.php | grep "2:3:"
+grep "'name'" app/etc/env.php | grep -q "2:3:"
 grep -q '_reEncryptSystemConfigurationValues - start' test.txt
 grep -q '_reEncryptSystemConfigurationValues - end'   test.txt
 grep -q '_reEncryptCreditCardNumbers - skipping' test.txt


### PR DESCRIPTION
This is https://github.com/genecommerce/module-encryption-key-manager/pull/30 but with a test case

- e8ae641e7b6330a367fb55c64a8fd6ba245a4f28 This was necessary to ensure the encryptor for this section was initialised with the new key for re-encryption
- 9368c9cc60ec65d3423c614fecbac58f83a4ecd3 to regenerate the config hash after updating values