### PR TITLE
Run tests in production mode

### DIFF
--- a/dev/test.sh
+++ b/dev/test.sh
@@ -12,6 +12,9 @@ CURRENT_TIMESTAMP=$(date +%s)
 ADMIN="adminuser$CURRENT_TIMESTAMP"
 PASSWORD='password123'
 
+echo "Putting magento into production mode, static content has already been generated"
+php bin/magento deploy:mode:set production -s
+
 echo "Stubbing in some test data"
 vendor/bin/n98-magerun2 --version
 vendor/bin/n98-magerun2 admin:user:create --no-interaction --admin-user "$ADMIN" --admin-email "example$CURRENT_TIMESTAMP@example.com" --admin-password $PASSWORD --admin-firstname adminuser --admin-lastname adminuser


### PR DESCRIPTION
The `di:compile` steps have already been completed while building magento. So we can run the tests in production mode, provided we dont hit the frontend and try and load any static content.