### PR TITLE
Improve performance with large data sets

### DIFF
--- a/Service/ChangeEncryptionKey.php
+++ b/Service/ChangeEncryptionKey.php
@@ -115,6 +115,11 @@ class ChangeEncryptionKey extends MageChanger
                 $updatedCount++;
             }
 
+            $currentMin = $currentMax;
+            if (empty($pairsToUpdate)) {
+                continue;
+            }
+
             $columnsSql = $this->buildColumnsSqlPart(['entity_id', 'cc_number_enc']);
             $valuesSql = $this->buildValuesSqlPart($pairsToUpdate);
             $onDuplicateSql = $this->buildOnDuplicateSqlPart(['cc_number_enc']);
@@ -129,7 +134,6 @@ class ChangeEncryptionKey extends MageChanger
                 $onDuplicateSql
             );
             $this->getConnection()->query($insertSql, $bind);
-            $currentMin = $currentMax;
             $this->writeOutput("running total records updated: $updatedCount", OutputInterface::VERBOSITY_VERBOSE);
         }
 

--- a/Service/ChangeEncryptionKey.php
+++ b/Service/ChangeEncryptionKey.php
@@ -32,13 +32,14 @@ class ChangeEncryptionKey extends MageChanger
     }
 
     /**
-     * @param string $text
+     * @param $text
+     * @param int $type
      * @return void
      */
-    private function writeOutput($text)
+    private function writeOutput($text, $type = OutputInterface::OUTPUT_NORMAL)
     {
         if ($this->output instanceof OutputInterface) {
-            $this->output->writeln($text);
+            $this->output->writeln($text, $type);
         }
     }
 
@@ -69,22 +70,54 @@ class ChangeEncryptionKey extends MageChanger
         }
         $this->writeOutput('_reEncryptCreditCardNumbers - start');
         $table = $this->getTable('sales_order_payment');
-        $select = $this->getConnection()->select()->from($table, ['entity_id', 'cc_number_enc']);
 
-        $attributeValues = $this->getConnection()->fetchPairs($select);
-        // save new values
-        foreach ($attributeValues as $valueId => $value) {
-            // GENE CHANGE START
-            if (!$value) {
-                continue;
+        $batchSize = 10000; // TODO worth making configurable?
+
+        $minId = (int) $this->getConnection()->fetchOne(
+            $this->getConnection()->select()
+                ->from($table, ['min(entity_id) AS min_id'])
+        );
+        $maxId = (int) $this->getConnection()->fetchOne(
+            $this->getConnection()->select()
+                ->from($table, ['max(entity_id) AS max_id'])
+        );
+        $totalCount = ($maxId - $minId) + 1; // the numbers are inclusive so add 1
+
+        $numberOfBatches = ceil($totalCount / $batchSize);
+        $this->writeOutput("_reEncryptCreditCardNumbers - total possible records: $totalCount");
+        $this->writeOutput("_reEncryptCreditCardNumbers - batch size:             $batchSize");
+        $this->writeOutput("_reEncryptCreditCardNumbers - batch count:            $numberOfBatches");
+
+        $updatedCount = 0;
+        $currentMin = $minId;
+        for ($i = 0; $i < $numberOfBatches; $i++) {
+            $currentMax = $currentMin + $batchSize;
+            $select = $this->getConnection()->select()
+                ->from($table, ['entity_id', 'cc_number_enc'])
+                ->where("entity_id >= ?", $currentMin)
+                ->where("entity_id < ?", $currentMax);
+
+            $this->writeOutput((string)$select, OutputInterface::VERBOSITY_VERBOSE);
+
+            $attributeValues = $this->getConnection()->fetchPairs($select);
+            foreach ($attributeValues as $valueId => $value) {
+                if (!$value) {
+                    continue;
+                }
+                // TODO can we collect these, and do the updates in batches as the updates are the limiting factor
+                // https://stackoverflow.com/a/3466
+                $this->getConnection()->update(
+                    $table,
+                    ['cc_number_enc' => $this->encryptor->encrypt($this->encryptor->decrypt($value))],
+                    ['entity_id = ?' => (int)$valueId]
+                );
+                $updatedCount++;
             }
-            // GENE CHANGE END
-            $this->getConnection()->update(
-                $table,
-                ['cc_number_enc' => $this->encryptor->encrypt($this->encryptor->decrypt($value))],
-                ['entity_id = ?' => (int)$valueId]
-            );
+            $currentMin = $currentMax;
+            $this->writeOutput("running total records updated: $updatedCount", OutputInterface::VERBOSITY_VERBOSE);
         }
+
+        $this->writeOutput("_reEncryptCreditCardNumbers - total records updated:   $updatedCount");
         $this->writeOutput('_reEncryptCreditCardNumbers - end');
     }
 }

--- a/dev/stub_sales_order_payment.php
+++ b/dev/stub_sales_order_payment.php
@@ -1,0 +1,31 @@
+<?php
+use Magento\Framework\App\Bootstrap;
+require_once '/var/www/html/app/bootstrap.php';
+
+$bootstrap = Bootstrap::create(BP, $_SERVER);
+$obj = $bootstrap->getObjectManager();
+
+/** @var \Magento\Framework\App\ResourceConnection $connection */
+$connection = $obj->get(\Magento\Framework\App\ResourceConnection::class);
+$connection->getConnection()->query('SET FOREIGN_KEY_CHECKS = 0;');
+$connection->getConnection()->query('delete from sales_order_payment where parent_id=1;');
+
+/** @var \Magento\Framework\Encryption\EncryptorInterface $encryptor */
+$encryptor = $obj->get(\Magento\Framework\Encryption\EncryptorInterface::class);
+$ccNumberEnc = $encryptor->encrypt('cc_number_enc_abc123');
+
+$rowData = "(1, '$ccNumberEnc'),";
+
+$insertQueryNull = trim('INSERT INTO sales_order_payment (parent_id, cc_number_enc) VALUES ' . str_repeat($rowData, 10000), ", ");
+for ($i = 0; $i < 100; $i++) {
+    $connection->getConnection()->query($insertQueryNull);
+}
+$connection->getConnection()->query('SET FOREIGN_KEY_CHECKS = 1;');
+
+// Get the total count of records
+$countSelect = $connection->getConnection()->select()
+    ->from('sales_order_payment', ['COUNT(*) AS total_count']);
+$totalCount = $connection->getConnection()->fetchOne($countSelect);
+
+echo "There are $totalCount items in sales_order_payment" . PHP_EOL;
+echo "DONE stub_sales_order_payment.php". PHP_EOL;

--- a/dev/stub_sales_order_payment.php
+++ b/dev/stub_sales_order_payment.php
@@ -17,7 +17,7 @@ $ccNumberEnc = $encryptor->encrypt('cc_number_enc_abc123');
 $rowData = "(1, '$ccNumberEnc'),";
 
 $insertQueryNull = trim('INSERT INTO sales_order_payment (parent_id, cc_number_enc) VALUES ' . str_repeat($rowData, 10000), ", ");
-for ($i = 0; $i < 100; $i++) {
+for ($i = 0; $i < 250; $i++) {
     $connection->getConnection()->query($insertQueryNull);
 }
 $connection->getConnection()->query('SET FOREIGN_KEY_CHECKS = 1;');

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -48,7 +48,7 @@ vendor/bin/n98-magerun2 db:query "insert into fake_json_table(text_column) value
 vendor/bin/n98-magerun2 db:query "select * from fake_json_table";
 
 echo "Stubbing in a large volume of data to sales_order_payment"
-vendor/bin/n98-magerun2 db:query "delete from sales_order_payment where parent_id=1";
+php vendor/gene/module-encryption-key-manager/dev/stub_sales_order_payment.php
 
 echo "";echo "";
 

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -54,12 +54,13 @@ echo "";echo "";
 
 echo "Verifying commands need to use --force"
 
-php bin/magento gene:encryption-key-manager:generate -vvv > test.txt || true;
+time php bin/magento gene:encryption-key-manager:generate -vvv > test.txt || true;
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: generate needs to run with force"
 else
     echo "FAIL: generate needs to run with force" && false
 fi
+cat test.txt
 
 php bin/magento gene:encryption-key-manager:invalidate > test.txt || true
 if grep -q 'Run with --force' test.txt; then

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -38,7 +38,7 @@ echo "";echo "";
 
 echo "Verifying commands need to use --force"
 
-php bin/magento gene:encryption-key-manager:generate > test.txt || true;
+php bin/magento gene:encryption-key-manager:generate -vvv > test.txt || true;
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: generate needs to run with force"
 else

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -54,13 +54,12 @@ echo "";echo "";
 
 echo "Verifying commands need to use --force"
 
-time php bin/magento gene:encryption-key-manager:generate -vvv > test.txt || true;
+php bin/magento gene:encryption-key-manager:generate -vvv > test.txt || true;
 if grep -q 'Run with --force' test.txt; then
     echo "PASS: generate needs to run with force"
 else
     echo "FAIL: generate needs to run with force" && false
 fi
-cat test.txt
 
 php bin/magento gene:encryption-key-manager:invalidate > test.txt || true
 if grep -q 'Run with --force' test.txt; then
@@ -102,7 +101,7 @@ echo "";echo "";
 
 echo "Generating a new encryption key"
 grep -q "$ENCRYPTED_ENV_VALUE" app/etc/env.php
-php bin/magento gene:encryption-key-manager:generate --force  > test.txt
+time php bin/magento gene:encryption-key-manager:generate --force  > test.txt
 if grep -q "$ENCRYPTED_ENV_VALUE" app/etc/env.php; then
     echo "FAIL: The old encrypted value in env.php was not updated" && false
 fi
@@ -112,6 +111,7 @@ grep -q '_reEncryptSystemConfigurationValues - end'   test.txt
 grep -q '_reEncryptCreditCardNumbers - start' test.txt
 grep -q '_reEncryptCreditCardNumbers - end'   test.txt
 echo "PASS"
+cat test.txt
 echo "";echo "";
 
 echo "Generating a new encryption key - skipping _reEncryptCreditCardNumbers"

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -30,6 +30,10 @@ FAKE_RP_TOKEN=$(vendor/bin/n98-magerun2 dev:encrypt 'abc123')
 vendor/bin/n98-magerun2 db:query "update admin_user set rp_token='$FAKE_RP_TOKEN' where username='$ADMIN'"
 echo "Generated FAKE_RP_TOKEN=$FAKE_RP_TOKEN and assigned to $ADMIN"
 
+echo "Stubbing in a large volume of data to sales_order_payment"
+vendor/bin/n98-magerun2 db:query "delete from sales_order_payment where parent_id=1";
+
+
 echo "";echo "";
 
 echo "Verifying commands need to use --force"

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -49,6 +49,7 @@ vendor/bin/n98-magerun2 db:query "select * from fake_json_table";
 
 echo "Stubbing in a large volume of data to sales_order_payment"
 php vendor/gene/module-encryption-key-manager/dev/stub_sales_order_payment.php
+vendor/bin/n98-magerun2 db:query "select cc_number_enc from sales_order_payment where parent_id=1 limit 5";
 
 echo "";echo "";
 
@@ -112,6 +113,7 @@ grep -q '_reEncryptCreditCardNumbers - start' test.txt
 grep -q '_reEncryptCreditCardNumbers - end'   test.txt
 echo "PASS"
 cat test.txt
+vendor/bin/n98-magerun2 db:query "select cc_number_enc from sales_order_payment where parent_id=1 limit 5";
 echo "";echo "";
 
 echo "Generating a new encryption key - skipping _reEncryptCreditCardNumbers"


### PR DESCRIPTION
resolves https://github.com/genecommerce/module-encryption-key-manager/issues/9

To improve pefromance
- Page over data to prevent loading all into memory
- Batch the update commands so we don't have to to multiple individual `update` queries

TODO
- We should profile at the end in some manner for a concrete measurement
- get something in CI for this
- Address TODO comments in PR

# Summary

- Original implementation - 2.5 million records ~= 8m46s
- Proposed implementation - 2.5 million records ~= 1m4s
- Proposed implementation - 25 million records ~= 11m1s

# Baseline build

This was generated by making a branch with the original `ChangeEncryptionKey.php` file and seeing how it peformed in the same way.

For posterity https://github.com/genecommerce/module-encryption-key-manager/pull/41

```
Generating a new encryption key

real    8m46.067s
user    1m57.702s
sys     0m54.372s
PASS
A new key will be generated for re-encryption, use "--key" to specify a custom key.
The system currently has 1 keys
Generating a new encryption key using the magento core class
_reEncryptSystemConfigurationValues - start
_reEncryptSystemConfigurationValues - end
_reEncryptCreditCardNumbers - start
_reEncryptCreditCardNumbers - end
reEncryptEnvConfigurationValues - start
reEncryptEnvConfigurationValues - end
Cleaning cache
Done
cc_number_enc
1:3:Y+Vfqd/P2VFws/1d1l3KUm7DefiEK+8UuPXsjZLPy5yiniWFWUbV4S7YiMQ9VQWV
1:3:ObbdarSNVDDDlbp+Wzs8lkrUNGGSXiEnKNa6J2qztFchM5w8ewKArbyitG95spU1
1:3:dVCvUsULbR5MThPjiZupC96cH/BsIzAKI9Xt3kEDA3PHAktee1wSnLq5WUlVwfJ3
1:3:f42nrfoDfbZxOah560YcrdaD964ClS98QDv5sIi9pM87rcxpamt84r8Y1YS8Ngaa
1:3:pmMR3kjiuo9Ffqrx+a5I3VCyGtjCHeRc6hVQgz+m4zcQvf7QW7I9csNT86un/eUH
```

# New build

https://app.circleci.com/pipelines/github/genecommerce/module-encryption-key-manager/100/workflows/31a8735c-5a08-4add-a5c2-13e1d6c452f9/jobs/94

```
Generating a new encryption key

real    1m4.381s
user    0m11.750s
sys     0m1.129s
PASS
A new key will be generated for re-encryption, use "--key" to specify a custom key.
The system currently has 1 keys
Generating a new encryption key using the magento core class
_reEncryptSystemConfigurationValues - start
_reEncryptSystemConfigurationValues - end
_reEncryptCreditCardNumbers - start
_reEncryptCreditCardNumbers - total possible records: 2500000
_reEncryptCreditCardNumbers - batch size:             10000
_reEncryptCreditCardNumbers - batch count:            250
_reEncryptCreditCardNumbers - total records updated:  2500000
_reEncryptCreditCardNumbers - end
reEncryptEnvConfigurationValues - start
reEncryptEnvConfigurationValues - end
Cleaning cache
Done
cc_number_enc
1:3:pU72eUmaUyl8zt/+6urRRwXZkQOhOLH5f46wXQvnsIpeX7wmL1R88+scz+rw4utf
1:3:pDFpTbclXYOekn0qhbVmlLYkBWdpksAKe8/2azFXxbaNwpCmiSscdqn30PdTWv1j
1:3:IY0C8vwgATh4xa6Tlz1f7SBgQ77Db9jityxA3JAWSdR/Fhm0aPxWVDiogINr/mIa
1:3:CUbE6GMFaAgOm0Hn3y1FsofhCsnwYh+q9nJX7alYzbgkXkg7zhDqZ9sjjuRIhP+t
1:3:HUG3gXyIXJs7MvdaJqbT3cg9+5qR3up9lb3k5MoxF7VwSpBRYtXzArwjO1qlG6nU
```

# Extra large data set

25 mil rows

```
Generating a new encryption key

real    11m0.911s
user    1m58.354s
sys     0m10.758s
PASS
A new key will be generated for re-encryption, use "--key" to specify a custom key.
The system currently has 1 keys
Generating a new encryption key using the magento core class
_reEncryptSystemConfigurationValues - start
_reEncryptSystemConfigurationValues - end
_reEncryptCreditCardNumbers - start
_reEncryptCreditCardNumbers - total possible records: 25000000
_reEncryptCreditCardNumbers - batch size:             10000
_reEncryptCreditCardNumbers - batch count:            2500
_reEncryptCreditCardNumbers - total records updated:  25000000
_reEncryptCreditCardNumbers - end
reEncryptEnvConfigurationValues - start
reEncryptEnvConfigurationValues - end
Cleaning cache
Done
cc_number_enc
1:3:8hhO5NotWUFLfPAzybRUpojMCZoinhlvWjwQz7h5fY7kWqg4XEgou4IoRtcT50Gj
1:3:9/MFBMZzd/keueHRSYLaB3+WKnbHpdJiATswS8C+xqjdjk2X4TvS71fTPwWRUAoS
1:3:FwMeT8GBvLoeqSN59cvxfCKhmfB/LvgJoX4DoIComQ7hFVdn/GVDsnrRfzgfGtz9
1:3:UYp/qBO3yS/QropCcwsh3VCSlKUHUT0Nhbe79vTMM6FvG99wV27yje6yqhHRxL0a
1:3:O6K5ZOgzFDdg2B5tlAN+Gh9B9dXg1Kn8zyIp5BD5bsAdYYdUAOFLMWp0y88qh3+c
```