### PR TITLE
Fix #40

### DIFF
--- a/Service/ReencryptEnvSystemConfigurationValues.php
+++ b/Service/ReencryptEnvSystemConfigurationValues.php
@@ -46,6 +46,9 @@ class ReencryptEnvSystemConfigurationValues
         $this->deploymentConfig->resetData();
         $this->encryptor = $this->encryptorFactory->create();
         $systemConfig = $this->deploymentConfig->get('system');
+        if (!$systemConfig) {
+            return;
+        }
         $systemConfig = $this->iterateSystemConfig($systemConfig);
 
         $encryptSegment = new ConfigData(ConfigFilePool::APP_ENV);


### PR DESCRIPTION
> Gene\EncryptionKeyManager\Service\ReencryptEnvSystemConfigurationValues::iterateSystemConfig(): Argument https://github.com/genecommerce/module-encryption-key-manager/pull/1 ($systemConfig) must be of type array, null given, called in app/code/Gene/EncryptionKeyManager/Service/ReencryptEnvSystemConfigurationValues.php on line 49

https://github.com/genecommerce/module-encryption-key-manager/issues/40

Ensure we only ever handle situations where the system config is provided.

Before fix

```
$ php bin/magento gene:enc:generate --force --skip-saved-credit-cards
A new key will be generated for re-encryption, use "--key" to specify a custom key.
The system currently has 25 keys
Generating a new encryption key using the magento core class
_reEncryptSystemConfigurationValues - start
_reEncryptSystemConfigurationValues - end
_reEncryptCreditCardNumbers - skipping
reEncryptEnvConfigurationValues - start
Gene\EncryptionKeyManager\Service\ReencryptEnvSystemConfigurationValues::iterateSystemConfig(): Argument #1 ($systemConfig) must be of type array, null given, called in /var/www/html/module-encryption-key-manager/Service/ReencryptEnvSystemConfigurationValues.php on line 49
```

After fix

```
$ php bin/magento gene:enc:generate --force --skip-saved-credit-cards
A new key will be generated for re-encryption, use "--key" to specify a custom key.
The system currently has 26 keys
Generating a new encryption key using the magento core class
_reEncryptSystemConfigurationValues - start
_reEncryptSystemConfigurationValues - end
_reEncryptCreditCardNumbers - skipping
reEncryptEnvConfigurationValues - start
reEncryptEnvConfigurationValues - end
Cleaning cache
Done

```