### PR TITLE
[FIX] Gene_EncryptionKeyManager: Fix bug prevent multiple JSON field updates

### DIFF
--- a/Console/ReencryptColumn.php
+++ b/Console/ReencryptColumn.php
@@ -130,8 +130,7 @@ class ReencryptColumn extends Command
                 $select = $select->where("($field LIKE '_:_:____%' OR $field LIKE '__:_:____%')")
                     ->where("$field NOT LIKE ?", "$latestKeyNumber:_:__%");
             } else {
-                $select = $select->where("($field LIKE '{%_:_:____%}' OR $field LIKE '{%__:_:____%}')")
-                    ->where("$field NOT LIKE ?", "{%$latestKeyNumber:_:__%}");
+                $select = $select->where("($field LIKE '{%_:_:____%}' OR $field LIKE '{%__:_:____%}')");
             }
             $result = $connection->fetchAll($select);
             if (empty($result)) {
@@ -146,9 +145,10 @@ class ReencryptColumn extends Command
                 if ($jsonField !== null) {
                     $fieldData = $this->jsonSerializer->unserialize($value);
                     $value = $fieldData[$jsonField] ?? '';
-                }
-                if ($value === '') {
-                    continue;
+                    // Prevent re-processing fields & processing empty fields
+                    if (strpos($value, "$latestKeyNumber:") === 0 || $value === '') {
+                        continue;
+                    }
                 }
                 $output->writeln("$identifier: {$row[$identifier]}");
                 $output->writeln("ciphertext_old: " . $value);


### PR DESCRIPTION
* Remove WHERE clause that was preventing multiple encrypted fields in a JSON blob from processing
* Add logic in processing loop to prevent re-processing fields that have already been re-encrypted