### PR TITLE
Don't logging not encrypted types values

### DIFF
--- a/Plugin/LogDecrypts.php
+++ b/Plugin/LogDecrypts.php
@@ -5,6 +5,7 @@ namespace Gene\EncryptionKeyManager\Plugin;
 use Psr\Log\LoggerInterface;
 use Magento\Framework\Encryption\Encryptor;
 use Magento\Framework\App\DeploymentConfig;
+use Gene\EncryptionKeyManager\Model\EncodingHelper;
 
 class LogDecrypts
 {
@@ -27,7 +28,8 @@ class LogDecrypts
     public function __construct(
         Encryptor $encryptor,
         DeploymentConfig $deploymentConfig,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly EncodingHelper $encodingHelper
     ) {
         $this->keyCount = count(explode(PHP_EOL, $encryptor->exportKeys())) - 1;
 
@@ -62,6 +64,11 @@ class LogDecrypts
             }
             if ($this->onlyLogOldKeyDecryptions && str_starts_with($data, $this->keyCount . ':')) {
                 // We are decrypting a value identified by the current maximum key, no need to log
+                return $result;
+            }
+
+            // don't logging values don't like as an encrypted value
+            if (!$this->encodingHelper->isEncryptedValue()) {
                 return $result;
             }
 

--- a/Plugin/LogDecrypts.php
+++ b/Plugin/LogDecrypts.php
@@ -68,7 +68,7 @@ class LogDecrypts
             }
 
             // don't logging values don't like as an encrypted value
-            if (!$this->encodingHelper->isEncryptedValue()) {
+            if (!$this->encodingHelper->isEncryptedValue($data)) {
                 return $result;
             }
 


### PR DESCRIPTION
In some cases some columns historically could have encrypted and not encrypted values. In our case it was `rp_token` column in `customer_entity` table.
Due to our prev login in plugin we don't expect that. So I have added just additional simple validation to avoid erroneous logged data